### PR TITLE
Don't have to start the editor in the environment's folder for map loading to work

### DIFF
--- a/src/editor/dmi.rs
+++ b/src/editor/dmi.rs
@@ -33,10 +33,10 @@ pub struct IconCache {
 }
 
 impl IconCache {
-    pub fn retrieve(&mut self, factory: &mut Factory, path: &Path) -> Option<&IconFile> {
-        match self.map.entry(path.to_owned()) {
+    pub fn retrieve(&mut self, factory: &mut Factory, base_path: &Path, relative_file_path: &Path) -> Option<&IconFile> {
+        match self.map.entry(relative_file_path.to_owned()) {
             Entry::Occupied(entry) => entry.into_mut().as_ref(),
-            Entry::Vacant(entry) => entry.insert(load(factory, path)).as_ref(),
+            Entry::Vacant(entry) => entry.insert(load(factory, &base_path.join(relative_file_path))).as_ref(),
         }
     }
 

--- a/src/editor/main.rs
+++ b/src/editor/main.rs
@@ -826,6 +826,7 @@ impl EditorScene {
                 map.rendered[map.z_current] = Some(self.map_renderer.prepare(
                     &mut self.factory,
                     &env.objtree,
+                    &env.path.parent().expect("invalid environment file path"),
                     &map.dmm,
                     map.z_current));
             }

--- a/src/editor/map_renderer.rs
+++ b/src/editor/map_renderer.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use gfx;
 use gfx::traits::{Factory as FactoryTrait, FactoryExt};
 use {Resources, Factory, Encoder, ColorFormat, RenderTargetView, Texture};
@@ -84,7 +86,7 @@ impl MapRenderer {
     }
 
     #[must_use]
-    pub fn prepare(&mut self, factory: &mut Factory, objtree: &ObjectTree, map: &Map, z: usize) -> RenderedMap {
+    pub fn prepare(&mut self, factory: &mut Factory, objtree: &ObjectTree, base_path: &Path, map: &Map, z: usize) -> RenderedMap {
         let start = ::std::time::Instant::now();
 
         // collect the atoms
@@ -98,7 +100,7 @@ impl MapRenderer {
                     };
                     match atom.get_var("icon", objtree) {
                         &Constant::Resource(ref path) | &Constant::String(ref path) => {
-                            let _ = self.icons.retrieve(factory, path.as_ref());
+                            let _ = self.icons.retrieve(factory, base_path, path.as_ref());
                         },
                         _ => continue,
                     }
@@ -128,7 +130,7 @@ impl MapRenderer {
             };
             let dir = atom.get_var("dir", objtree).to_int().unwrap_or(::dmi::SOUTH);
 
-            let icon_file = match self.icons.retrieve(factory, icon.as_ref()) {
+            let icon_file = match self.icons.retrieve(factory, base_path, icon.as_ref()) {
                 Some(icon_file) => icon_file,
                 None => continue,
             };


### PR DESCRIPTION
Tested against TG's runtimestation.dmm and /vg/'s tgstation.dmm