### PR TITLE
Goon lexer fixes

### DIFF
--- a/src/dreammaker/lexer.rs
+++ b/src/dreammaker/lexer.rs
@@ -639,11 +639,16 @@ impl<'ctx, I: Iterator<Item=io::Result<u8>>> Lexer<'ctx, I> {
 
         // read the first character and check for being a comment
         let mut comment = None;
-        match self.next() {
+        let firstchar = self.next();
+        match firstchar {
             Some(b'*') => comment = Some(DocComment::new(CommentKind::Block, DocTarget::FollowingItem)),
             Some(b'!') => comment = Some(DocComment::new(CommentKind::Block, DocTarget::EnclosingItem)),
+            _ => {},
+        }
+
+        match firstchar {
             Some(ch) => buffer[1] = ch,
-            None => {}
+            None => {},
         }
 
         loop {

--- a/src/dreammaker/lexer.rs
+++ b/src/dreammaker/lexer.rs
@@ -824,8 +824,14 @@ impl<'ctx, I: Iterator<Item=io::Result<u8>>> Lexer<'ctx, I> {
     fn read_resource(&mut self) -> String {
         let start_loc = self.location();
         let mut buf = Vec::new();
+        let mut backslash = false;
         loop {
             match self.next() {
+                Some(ch) if backslash => {
+                    backslash = false;
+                    buf.push(ch);
+                },
+                Some(b'\\') => backslash = true,
                 Some(b'\'') => break,
                 Some(ch) => buf.push(ch),
                 None => {


### PR DESCRIPTION
Two very small fixes for issues that were preventing autocompletion from working on goon 2016:

- Skipping empty block comments (that are occasionally used as section separators) like `/**/` would skip the second `*` and never find the end of the comment.
- Hack to fix parsing resource files that include an escape sequence in them, notably `\'`.
