### PR TITLE
Add global.vars to builtins

### DIFF
--- a/src/dreammaker/builtins.rs
+++ b/src/dreammaker/builtins.rs
@@ -207,6 +207,7 @@ pub fn register_builtins(tree: &mut ObjectTree) -> Result<(), DMError> {
     }
 
     entries! {
+        var/const/vars;
         // directions
         var/const/NORTH = int!(1);
         var/const/SOUTH = int!(2);


### PR DESCRIPTION
because `- visit_follow: field does not exist: "vars" on (global)`