### PR TITLE
must_not_override

### DIFF
--- a/src/dreamchecker/README.md
+++ b/src/dreamchecker/README.md
@@ -52,9 +52,13 @@ be enabled:
 #ifdef SPACEMAN_DMM
 	#define RETURN_TYPE(X) set SpacemanDMM_return_type = X
 	#define SHOULD_CALL_PARENT(X) set SpacemanDMM_should_call_parent = X
+	#define UNLINT(X) SpacemanDMM_unlint(X)
+	#define SHOULD_NOT_OVERRIDE(X) set SpacemanDMM_should_not_override = X
 #else
 	#define RETURN_TYPE(X)
 	#define SHOULD_CALL_PARENT(X)
+	#define UNLINT(X) X
+	#define SHOULD_NOT_OVERRIDE(X)
 #endif
 ```
 
@@ -79,3 +83,8 @@ of the proc it is set on which do not contain any `..()` parent calls. This can
 help with finding situations where a signal or other important handling in the
 parent proc is being skipped. Child procs may set this setting to `0` instead
 to override the check.
+
+### Should not override
+Use `set SpacemanDMM_should_not_override = 1` to raise a warning for any child
+procs that override this one, regardless of if it calls parent or not.
+This functions in a similar way to the `final` keyword in some languages.

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -326,6 +326,7 @@ impl<'o> AnalyzeObjectTree<'o> {
             objtree,
             return_type,
             must_call_parent: Default::default(),
+            must_not_override: Default::default(),
             used_kwargs: Default::default(),
         }
     }
@@ -349,6 +350,19 @@ impl<'o> AnalyzeObjectTree<'o> {
                                 .with_component(dm::Component::DreamChecker)
                                 .register(self.context),
                         }
+                    }
+                } else if name == "SpacemanDMM_should_not_override" {
+                    match match value.as_term() {
+                        Some(Term::Int(0)) => Some(false),
+                        Some(Term::Int(1)) => Some(true),
+                        Some(Term::Ident(i)) if i == "FALSE" => Some(false),
+                        Some(Term::Ident(i)) if i == "TRUE" => Some(true),
+                        _ => None,
+                    } {
+                        Some(value) => { self.must_not_override.insert(proc, value); },
+                        None => error(statement.location, format!("invalid value for {}: {:?}", name, value))
+                            .set_severity(Severity::Warning)
+                            .register(self.context)
                     }
                 } else if name == "SpacemanDMM_should_call_parent" {
                     // Maybe this should be using constant evaluation, but for now accept TRUE and FALSE directly.
@@ -542,16 +556,24 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         }
         self.visit_block(block);
 
-        if !self.calls_parent && self.proc_ref.parent_proc().is_some() {
+        if self.proc_ref.parent_proc().is_some() {
             //eprintln!("{:?}", self.env.must_call_parent);
-            let mut next = Some(self.proc_ref);
+            let mut next = Some(self.proc_ref); 
             while let Some(current) = next {
-                if let Some(&must) = self.env.must_call_parent.get(&current) {
-                    if must {
-                        error(self.proc_ref.location, format!("proc never calls parent, required by {}", current))
+                if let Some(&musnt) = self.env.must_not_override.get(&current) {
+                    if musnt {
+                        error(self.proc_ref.location, format!("proc overrides parent, prohibited by {}", current))
                             .register(self.context);
                     }
-                    break;
+                }
+                if !self.calls_parent {
+                    if let Some(&must) = self.env.must_call_parent.get(&current) {
+                        if must {
+                            error(self.proc_ref.location, format!("proc never calls parent, required by {}", current))
+                                .register(self.context);
+                        }
+                        break;
+                    }
                 }
                 next = current.parent_proc();
             }

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -312,6 +312,7 @@ pub struct AnalyzeObjectTree<'o> {
 
     return_type: HashMap<ProcRef<'o>, TypeExpr<'o>>,
     must_call_parent: HashMap<ProcRef<'o>, bool>,
+    must_not_override: HashMap<ProcRef<'o>, bool>,
     // Debug(ProcRef) -> KwargInfo
     used_kwargs: BTreeMap<String, KwargInfo>,
 }

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -354,9 +354,7 @@ impl<'o> AnalyzeObjectTree<'o> {
                     }
                 } else if name == "SpacemanDMM_should_not_override" {
                     match match value.as_term() {
-                        Some(Term::Int(0)) => Some(false),
                         Some(Term::Int(1)) => Some(true),
-                        Some(Term::Ident(i)) if i == "FALSE" => Some(false),
                         Some(Term::Ident(i)) if i == "TRUE" => Some(true),
                         _ => None,
                     } {


### PR DESCRIPTION
This is meant to add a linter hint to prevent procs being overridden.

i hope to also add something similar for variables

This is basically `final` in other languages