### PR TITLE
Add warnings for ambiguous/incorrect BinaryOp::In

### DIFF
--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -613,12 +613,14 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                                 if unary.len() > 0 {
                                     error(location, format!("Found a unary operation on left side of an if(x in y) eg if(!a in b)"))
                                         .set_severity(Severity::Warning)
+                                        .with_note(location, "add parentheses around the 'in' expression, if(!(a in b))")
                                         .register(self.context);
                                 }
                             },
                             others => {
                                 error(location, format!("Found an operation on left side of an if(x in y), eg if(a || b in c)"))
                                         .set_severity(Severity::Warning)
+                                        .with_note(location, "add parentheses around the 'in' expression, if(a || (b in c))")
                                         .register(self.context);
                             }
                         };

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -748,7 +748,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                         if unary.len() > 0 {
                             error(location, format!("Found a unary {} on left side of an `in`", unary[0].name()))
                                 .set_severity(Severity::Warning)
-                                .with_note(location, "add parentheses around the 'in' expression, !(a in b)")
+                                .with_note(location, format!("add parentheses around the 'in' expression, {}(a in b)", unary[0].name()))
                                 .register(self.context);
                         }
                     },

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -763,7 +763,11 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                             .set_severity(Severity::Warning)
                             .register(self.context);
                     },
-                    others => {},
+                    Expression::TernaryOp{ cond, if_, else_ } => {
+                        error(location, format!("Found ternary op on left side of an `in`"))
+                            .set_severity(Severity::Warning)
+                            .register(self.context);
+                    },
                 };
                 let lty = self.visit_expression(location, lhs, None);
                 let rty = self.visit_expression(location, rhs, None);

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -746,18 +746,24 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 match &**lhs {
                     Expression::Base{unary, term, follow} => {
                         if unary.len() > 0 {
-                            error(location, format!("Found a unary operation on left side of an x in y eg !a in b"))
+                            error(location, format!("Found a unary {} on left side of an `in`", unary[0].name()))
                                 .set_severity(Severity::Warning)
                                 .with_note(location, "add parentheses around the 'in' expression, !(a in b)")
                                 .register(self.context);
                         }
                     },
-                    others => {
-                        error(location, format!("Found an operation on left side of an x in y, eg a || b in c"))
-                                .set_severity(Severity::Warning)
-                                .with_note(location, "add parentheses around the 'in' expression, a || (b in c)")
-                                .register(self.context);
-                    }
+                    Expression::BinaryOp{ op, lhs, rhs} => {
+                        error(location, format!("Found {} on left side of an `in`", op))
+                            .set_severity(Severity::Warning)
+                            .with_note(location, "add parentheses around the 'in' expression, a || (b in c)")
+                            .register(self.context);
+                    },
+                    Expression::AssignOp{ op, lhs, rhs} => {
+                        error(location, format!("Found assignment on left side of an `in`"))
+                            .set_severity(Severity::Warning)
+                            .register(self.context);
+                    },
+                    others => {},
                 };
                 let lty = self.visit_expression(location, lhs, None);
                 let rty = self.visit_expression(location, rhs, None);

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -755,7 +755,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                     Expression::BinaryOp{ op, lhs, rhs} => {
                         error(location, format!("Found {} on left side of an `in`", op))
                             .set_severity(Severity::Warning)
-                            .with_note(location, "add parentheses around the 'in' expression, a || (b in c)")
+                            .with_note(location, format!("add parentheses around the 'in' expression, a {} (b in c)", op))
                             .register(self.context);
                     },
                     Expression::AssignOp{ op, lhs, rhs} => {

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -1728,11 +1728,11 @@ where
 
         // This has the effect of stripping unnecessary parentheses, which
         // simplifies later logic.
-        if unary_ops.is_empty() && follow.is_empty() {
+        /*if unary_ops.is_empty() && follow.is_empty() {
             if let Term::Expr(expr) = term.elem {
                 return success(*expr);
             }
-        }
+        }*/
 
         success(Expression::Base {
             unary: unary_ops,


### PR DESCRIPTION
```
/mob/proc/bar()
	var/foo = 1
	var/list/L = list()
	if((1<<0) in L) // 1
		return
		
	if(foo && foo in L) // 2
		return
		
	if((foo && foo) in L) // 3
		return

	if(!foo in L) // 4
		return
		
	if(!(foo in L)) // 5
		return

	if(foo = 2 in L) // 6
		return
		
	if(foo ? 1 : 2 in L) // 7
		return
```
detects 2, 4, 6 but not 7 due to a precedence parsing issue (#122)
```
test.dm, line 7, column 2:
warning: Found && on left side of an `in`
- add parentheses around the 'in' expression, a && (b in c)

test.dm, line 13, column 2:
warning: Found a unary ! on left side of an `in`
- add parentheses around the 'in' expression, !(a in b)

test.dm, line 19, column 2:
warning: Found assignment on left side of an `in`
```