### PR TITLE
Add lints for private/protected vars and procs

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -31,6 +31,8 @@ Raised by DreamChecker:
 * `must_not_override` - `SpacemanDMM_should_not_override` directive
 * `must_call_parent` - `SpacemanDMM_should_call_parent` directive
 * `final_var` - `SpacemanDMM_final` var type
+* `private_proc` - `SpacemanDMM_private_proc` directive
+* `private_var` - `SpacemanDMM_private` var type
 * `ambiguous_in_lhs` - Raised on ambiguous operations on the left hand side of an `in` operation
 * `no_typehint_implicit_new` - Raised on the use of `new` where no typehint is avaliable
 * `field_access_static_type` - Raised on using `.field_name` on a variable with no typehint

--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -32,7 +32,9 @@ Raised by DreamChecker:
 * `must_call_parent` - `SpacemanDMM_should_call_parent` directive
 * `final_var` - `SpacemanDMM_final` var type
 * `private_proc` - `SpacemanDMM_private_proc` directive
+* `protected_proc` - `SpacemanDMM_protected_proc` directive
 * `private_var` - `SpacemanDMM_private` var type
+* `protected_var` - `SpacemanDMM_protected` var type
 * `ambiguous_in_lhs` - Raised on ambiguous operations on the left hand side of an `in` operation
 * `no_typehint_implicit_new` - Raised on the use of `new` where no typehint is avaliable
 * `field_access_static_type` - Raised on using `.field_name` on a variable with no typehint

--- a/src/dmdoc/main.rs
+++ b/src/dmdoc/main.rs
@@ -263,6 +263,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     is_const: decl.var_type.is_const,
                     is_tmp: decl.var_type.is_tmp,
                     is_final: decl.var_type.is_final,
+                    is_private: decl.var_type.is_private,
                     path: &decl.var_type.type_path,
                 });
                 parsed_type.vars.insert(name, Var {
@@ -888,6 +889,7 @@ struct VarType<'a> {
     is_const: bool,
     is_tmp: bool,
     is_final: bool,
+    is_private: bool,
     path: &'a [String],
 }
 

--- a/src/dmdoc/main.rs
+++ b/src/dmdoc/main.rs
@@ -264,6 +264,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     is_tmp: decl.var_type.is_tmp,
                     is_final: decl.var_type.is_final,
                     is_private: decl.var_type.is_private,
+                    is_protected: decl.var_type.is_protected,
                     path: &decl.var_type.type_path,
                 });
                 parsed_type.vars.insert(name, Var {
@@ -890,6 +891,7 @@ struct VarType<'a> {
     is_tmp: bool,
     is_final: bool,
     is_private: bool,
+    is_protected: bool,
     path: &'a [String],
 }
 

--- a/src/dreamchecker/README.md
+++ b/src/dreamchecker/README.md
@@ -116,7 +116,7 @@ Use the above definition of VAR_FINAL to declare vars as `SpacemanDMM_final`, `v
 Use `set SpacemanDMM_private_proc = 1` and `set SpacemanDMM_protected_proc = 1` to set procs as private and protected respectively.
 
 * Private procs can only be called by things of exactly the same type
-* Protected procs can only be call by things of the same type of subtypes
+* Protected procs can only be call by things of the same type or subtypes
 
 Additionally, Private procs cannot be overridden.
 

--- a/src/dreamchecker/README.md
+++ b/src/dreamchecker/README.md
@@ -36,8 +36,8 @@ DreamCheckers's whole-program analysis can find problems such as:
 * Calling the parent proc `..()` when no such parent exists.
 * Accesses like `L[1].foo` and `foo().bar` wherein `.` acts like `:` instead.
   * List accesses perform lookups according to the type appended to `/list`,
-    e.g. with `var/list/obj/L`, the type of `L[1]` will be `/obj` and a lookup
-    of `L[1].name` will not generate a warning.
+	e.g. with `var/list/obj/L`, the type of `L[1]` will be `/obj` and a lookup
+	of `L[1].name` will not generate a warning.
   * Proc calls will obey the [return type](#return-type) annotation if present.
 
 ## Configuration
@@ -62,12 +62,16 @@ be enabled:
 	#define UNLINT(X) SpacemanDMM_unlint(X)
 	#define SHOULD_NOT_OVERRIDE(X) set SpacemanDMM_should_not_override = X
 	#define VAR_FINAL var/SpacemanDMM_final
+	#define VAR_PRIVATE var/SpacemanDMM_private
+	#define VAR_PROTECTED var/SpacemanDMM_protected
 #else
 	#define RETURN_TYPE(X)
 	#define SHOULD_CALL_PARENT(X)
 	#define UNLINT(X) X
 	#define SHOULD_NOT_OVERRIDE(X)
 	#define VAR_FINAL var
+	#define VAR_PRIVATE var
+	#define VAR_PROTECTED var
 #endif
 ```
 
@@ -106,3 +110,17 @@ Use the above definition of VAR_FINAL to declare vars as `SpacemanDMM_final`, `v
 /a/type
   VAR_FINAL/foo = somevalue
 ```
+
+### Private / Protected procs
+
+Use `set SpacemanDMM_private_proc = 1` and `set SpacemanDMM_protected_proc = 1` to set procs as private and protected respectively.
+
+* Private procs can only be called by things of exactly the same type
+* Protected procs can only be call by things of the same type of subtypes
+
+Additionally, Private procs cannot be overridden.
+
+### Private / Protected vars
+
+Use the above definitions of VAR_PRIVATE and VAR_PROTECTED to declare vars as `SpacemanDMM_private`/`SpacemanDMM_protected`.
+These function the same way as the proc versions.

--- a/src/dreamchecker/README.md
+++ b/src/dreamchecker/README.md
@@ -36,8 +36,8 @@ DreamCheckers's whole-program analysis can find problems such as:
 * Calling the parent proc `..()` when no such parent exists.
 * Accesses like `L[1].foo` and `foo().bar` wherein `.` acts like `:` instead.
   * List accesses perform lookups according to the type appended to `/list`,
-	e.g. with `var/list/obj/L`, the type of `L[1]` will be `/obj` and a lookup
-	of `L[1].name` will not generate a warning.
+    e.g. with `var/list/obj/L`, the type of `L[1]` will be `/obj` and a lookup
+    of `L[1].name` will not generate a warning.
   * Proc calls will obey the [return type](#return-type) annotation if present.
 
 ## Configuration

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -645,6 +645,13 @@ pub fn check_var_defs(objtree: &ObjectTree, context: &Context) {
                         .with_note(decl.location, format!("declared final on {} here", parent.path))
                         .register(context);
                 }
+
+                if decl.var_type.is_private {
+                    DMError::new(typevar.value.location, format!("{} overrides private var {:?}", path, varname))
+                        .with_errortype("private_var")
+                        .with_note(decl.location, format!("declared private on {} here", parent.path))
+                        .register(context);
+                }
             }
         }
     }

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -1196,6 +1196,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                     if let Some(decl) = ty.get_var_declaration(name) {
                         if ty != self.ty && decl.var_type.is_private {
                             error(location, format!("field {:?} on {} is declared as private", name, ty))
+                                .with_errortype("private_var")
                                 .set_severity(Severity::Warning)
                                 .with_note(decl.location, "definition is here")
                                 .register(self.context);
@@ -1222,6 +1223,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                         if let Some((privateproc, is_private, decllocation)) = self.env.private.get_self_or_parent(proc) {
                             if is_private {
                                 error(location, format!("attempting to call private proc {} on {}", name, ty))
+                                    .with_errortype("private_proc")
                                     .with_note(decllocation, "prohibited by this private_proc annotation")
                                     .register(self.context);
                             }

--- a/src/dreamchecker/tests/private_tests.rs
+++ b/src/dreamchecker/tests/private_tests.rs
@@ -1,0 +1,118 @@
+
+extern crate dreamchecker as dc;
+
+use dc::test_helpers::*;
+
+pub const PRIVATE_PROC_ERRORS: &[(u32, u16, &str)] = &[
+    (5, 21, "proc overrides private parent, prohibited by /mob/proc/private"),
+    (11, 5, "/mob/subtype/proc/test2 attempting to call private proc /mob/proc/private2, types do not match"),
+    (12, 8, "/mob/subtype/proc/test2 attempting to call private proc /mob/proc/private2, types do not match"),
+    (15, 6, "/obj/proc/test attempting to call private proc /mob/proc/private2, types do not match"),
+    (17, 6, "/obj/proc/test attempting to call private proc /mob/proc/private, types do not match"),
+];
+
+#[test]
+fn private_proc() {
+    let code = r##"
+/mob/proc/private()
+    set SpacemanDMM_private_proc = TRUE
+/mob/proc/private2()
+    set SpacemanDMM_private_proc = TRUE
+/mob/subtype/private()
+    return
+/mob/proc/test()
+    private2()
+    src.private2()
+/mob/subtype/proc/test2()
+    private2()
+    src.private2()
+/obj/proc/test()
+    var/mob/M = new
+    M.private2()
+    var/mob/subtype/S = new
+    S.private()
+"##.trim();
+    check_errors_match(code, PRIVATE_PROC_ERRORS);
+}
+
+pub const PRIVATE_VAR_ERRORS: &[(u32, u16, &str)] = &[
+    (5, 9, "/mob/subtype overrides private var \"foo\""),
+    (12, 6, "field \"bar\" on /mob is declared as private"),
+    (14, 6, "field \"foo\" on /mob/subtype is declared as private"),
+];
+
+#[test]
+fn private_var() {
+    let code = r##"
+/mob
+    var/SpacemanDMM_private/foo = TRUE
+    var/SpacemanDMM_private/bar = TRUE
+/mob/subtype
+    foo = FALSE
+/mob/proc/test()
+    foo = FALSE
+/mob/subtype/proc/test2()
+    bar = FALSE
+/obj/proc/test()
+    var/mob/M = new
+    M.bar = TRUE
+    var/mob/subtype/S = new
+    S.foo = TRUE
+"##.trim();
+    check_errors_match(code, PRIVATE_VAR_ERRORS);
+}
+
+pub const PROTECTED_PROC_ERRORS: &[(u32, u16, &str)] = &[
+    (15, 6, "/obj/proc/test attempting to call protected proc /mob/proc/protected2"),
+    (17, 6, "/obj/proc/test attempting to call protected proc /mob/proc/protected"),
+];
+
+#[test]
+fn protected_proc() {
+    let code = r##"
+/mob/proc/protected()
+    set SpacemanDMM_protected_proc = TRUE
+/mob/proc/protected2()
+    set SpacemanDMM_protected_proc = TRUE
+/mob/subtype/protected()
+    return
+/mob/proc/test()
+    protected()
+    src.protected()
+/mob/subtype/proc/test2()
+    protected2()
+    src.protected2()
+/obj/proc/test()
+    var/mob/M = new
+    M.protected2()
+    var/mob/subtype/S = new
+    S.protected()
+"##.trim();
+    check_errors_match(code, PROTECTED_PROC_ERRORS);
+}
+
+pub const PROTECTED_VAR_ERRORS: &[(u32, u16, &str)] = &[
+    (12, 6, "field \"bar\" on /mob is declared as protected"),
+    (14, 6, "field \"foo\" on /mob/subtype is declared as protected"),
+];
+
+#[test]
+fn protected_var() {
+    let code = r##"
+/mob
+    var/SpacemanDMM_protected/foo = TRUE
+    var/SpacemanDMM_protected/bar = TRUE
+/mob/subtype
+    foo = FALSE
+/mob/proc/test()
+    foo = FALSE
+/mob/subtype/proc/test2()
+    bar = FALSE
+/obj/proc/test()
+    var/mob/M = new
+    M.bar = TRUE
+    var/mob/subtype/S = new
+    S.foo = TRUE
+"##.trim();
+    check_errors_match(code, PROTECTED_VAR_ERRORS);
+}

--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -671,6 +671,7 @@ pub struct VarType {
     pub is_const: bool,
     pub is_tmp: bool,
     pub is_final: bool,
+    pub is_private: bool,
     pub type_path: TreePath,
 }
 
@@ -694,7 +695,7 @@ impl VarType {
 
 impl FromIterator<String> for VarType {
     fn from_iter<T: IntoIterator<Item=String>>(iter: T) -> Self {
-        let (mut is_static, mut is_const, mut is_tmp, mut is_final) = (false, false, false, false);
+        let (mut is_static, mut is_const, mut is_tmp, mut is_final, mut is_private) = (false, false, false, false, false);
         let type_path = iter
             .into_iter()
             .skip_while(|p| {
@@ -703,6 +704,9 @@ impl FromIterator<String> for VarType {
                     true
                 } else if p == "SpacemanDMM_final" {
                     is_final = true;
+                    true
+                } else if p == "SpacemanDMM_private" {
+                    is_private = true;
                     true
                 } else if p == "const" {
                     is_const = true;
@@ -719,6 +723,7 @@ impl FromIterator<String> for VarType {
             is_const,
             is_tmp,
             is_final,
+            is_private,
             type_path,
         }
     }
@@ -737,6 +742,9 @@ impl fmt::Display for VarType {
         }
         if self.is_final {
             fmt.write_str("SpacemanDMM_final/")?;
+        }
+        if self.is_private {
+            fmt.write_str("private/")?;
         }
         for bit in self.type_path.iter() {
             fmt.write_str(bit)?;

--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -672,6 +672,7 @@ pub struct VarType {
     pub is_tmp: bool,
     pub is_final: bool,
     pub is_private: bool,
+    pub is_protected: bool,
     pub type_path: TreePath,
 }
 
@@ -695,7 +696,7 @@ impl VarType {
 
 impl FromIterator<String> for VarType {
     fn from_iter<T: IntoIterator<Item=String>>(iter: T) -> Self {
-        let (mut is_static, mut is_const, mut is_tmp, mut is_final, mut is_private) = (false, false, false, false, false);
+        let (mut is_static, mut is_const, mut is_tmp, mut is_final, mut is_private, mut is_protected) = (false, false, false, false, false, false);
         let type_path = iter
             .into_iter()
             .skip_while(|p| {
@@ -707,6 +708,9 @@ impl FromIterator<String> for VarType {
                     true
                 } else if p == "SpacemanDMM_private" {
                     is_private = true;
+                    true
+                } else if p == "SpacemanDMM_protected" {
+                    is_protected = true;
                     true
                 } else if p == "const" {
                     is_const = true;
@@ -724,6 +728,7 @@ impl FromIterator<String> for VarType {
             is_tmp,
             is_final,
             is_private,
+            is_protected,
             type_path,
         }
     }
@@ -744,7 +749,10 @@ impl fmt::Display for VarType {
             fmt.write_str("SpacemanDMM_final/")?;
         }
         if self.is_private {
-            fmt.write_str("private/")?;
+            fmt.write_str("SpacemanDMM_private/")?;
+        }
+        if self.is_protected {
+            fmt.write_str("SpacemanDMM_protected/")?;
         }
         for bit in self.type_path.iter() {
             fmt.write_str(bit)?;

--- a/src/dreammaker/objtree.rs
+++ b/src/dreammaker/objtree.rs
@@ -79,6 +79,7 @@ pub struct ProcDeclaration {
     pub location: Location,
     pub kind: ProcDeclKind,
     pub id: SymbolId,
+    pub is_private: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -906,7 +907,7 @@ impl ObjectTree {
     where
         I: Iterator<Item=&'a str>,
     {
-        let (mut is_declaration, mut is_static, mut is_const, mut is_tmp, mut is_final) = (false, false, false, false, false);
+        let (mut is_declaration, mut is_static, mut is_const, mut is_tmp, mut is_final, mut is_private) = (false, false, false, false, false, false);
 
         if is_var_decl(prev) {
             is_declaration = true;
@@ -914,12 +915,13 @@ impl ObjectTree {
                 Some(name) => name,
                 None => return Ok(None), // var{} block, children will be real vars
             };
-            while prev == "global" || prev == "static" || prev == "tmp" || prev == "const" || prev == "SpacemanDMM_final" {
+            while prev == "global" || prev == "static" || prev == "tmp" || prev == "const" || prev == "SpacemanDMM_final" || prev == "SpacemanDMM_private" {
                 if let Some(name) = rest.next() {
                     is_static |= prev == "global" || prev == "static";
                     is_const |= prev == "const";
                     is_tmp |= prev == "tmp";
                     is_final |= prev == "SpacemanDMM_final";
+                    is_private |= prev == "SpacemanDMM_private";
                     prev = name;
                 } else {
                     return Ok(None); // var/const{} block, children will be real vars
@@ -939,6 +941,7 @@ impl ObjectTree {
             is_const,
             is_tmp,
             is_final,
+            is_private,
             type_path,
         };
         var_type.suffix(&suffix);
@@ -988,6 +991,7 @@ impl ObjectTree {
                     location,
                     kind,
                     id: self.symbols.allocate(),
+                    is_private: false,
                 });
             }
         }

--- a/src/dreammaker/objtree.rs
+++ b/src/dreammaker/objtree.rs
@@ -80,6 +80,7 @@ pub struct ProcDeclaration {
     pub kind: ProcDeclKind,
     pub id: SymbolId,
     pub is_private: bool,
+    pub is_protected: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -907,7 +908,7 @@ impl ObjectTree {
     where
         I: Iterator<Item=&'a str>,
     {
-        let (mut is_declaration, mut is_static, mut is_const, mut is_tmp, mut is_final, mut is_private) = (false, false, false, false, false, false);
+        let (mut is_declaration, mut is_static, mut is_const, mut is_tmp, mut is_final, mut is_private, mut is_protected) = (false, false, false, false, false, false, false);
 
         if is_var_decl(prev) {
             is_declaration = true;
@@ -915,13 +916,14 @@ impl ObjectTree {
                 Some(name) => name,
                 None => return Ok(None), // var{} block, children will be real vars
             };
-            while prev == "global" || prev == "static" || prev == "tmp" || prev == "const" || prev == "SpacemanDMM_final" || prev == "SpacemanDMM_private" {
+            while prev == "global" || prev == "static" || prev == "tmp" || prev == "const" || prev == "SpacemanDMM_final" || prev == "SpacemanDMM_private" || prev == "SpacemanDMM_protected" {
                 if let Some(name) = rest.next() {
                     is_static |= prev == "global" || prev == "static";
                     is_const |= prev == "const";
                     is_tmp |= prev == "tmp";
                     is_final |= prev == "SpacemanDMM_final";
                     is_private |= prev == "SpacemanDMM_private";
+                    is_protected |= prev == "SpacemanDMM_protected";
                     prev = name;
                 } else {
                     return Ok(None); // var/const{} block, children will be real vars
@@ -942,6 +944,7 @@ impl ObjectTree {
             is_tmp,
             is_final,
             is_private,
+            is_protected,
             type_path,
         };
         var_type.suffix(&suffix);
@@ -992,6 +995,7 @@ impl ObjectTree {
                     kind,
                     id: self.symbols.allocate(),
                     is_private: false,
+                    is_protected: false,
                 });
             }
         }

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -1442,6 +1442,11 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                         .with_errortype("final_no_effect")
                         .register(self.context);
                 }
+                if var_type.is_private {
+                    DMError::new(type_path_start, "var/private has no effect here")
+                        .set_severity(Severity::Warning)
+                        .register(self.context);
+                }
                 let var_suffix = require!(self.var_suffix());
                 var_type.suffix(&var_suffix);
 

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -1443,7 +1443,14 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                         .register(self.context);
                 }
                 if var_type.is_private {
-                    DMError::new(type_path_start, "var/private has no effect here")
+                    DMError::new(type_path_start, "var/SpacemanDMM_private has no effect here")
+                        .with_errortype("private_var")
+                        .set_severity(Severity::Warning)
+                        .register(self.context);
+                }
+                if var_type.is_protected {
+                    DMError::new(type_path_start, "var/SpacemanDMM_protected has no effect here")
+                        .with_errortype("protected_var")
                         .set_severity(Severity::Warning)
                         .register(self.context);
                 }

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -991,6 +991,9 @@ handle_method_call! {
                                 if decl.var_type.is_final {
                                     declaration.push_str("/final");
                                 }
+                                if decl.var_type.is_private {
+                                    declaration.push_str("/private");
+                                }
                                 for bit in decl.var_type.type_path.iter() {
                                     declaration.push('/');
                                     declaration.push_str(&bit);

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -989,10 +989,13 @@ handle_method_call! {
                                     declaration.push_str("/tmp");
                                 }
                                 if decl.var_type.is_final {
-                                    declaration.push_str("/final");
+                                    declaration.push_str("/SpacemanDMM_final");
                                 }
                                 if decl.var_type.is_private {
-                                    declaration.push_str("/private");
+                                    declaration.push_str("/SpacemanDMM_private");
+                                }
+                                if decl.var_type.is_protected {
+                                    declaration.push_str("/SpacemanDMM_protected");
                                 }
                                 for bit in decl.var_type.type_path.iter() {
                                     declaration.push('/');


### PR DESCRIPTION
See unit tests for proof

from README
```md
### Private / Protected procs

Use `set SpacemanDMM_private_proc = 1` and 
`set SpacemanDMM_protected_proc = 1` to set procs as private and protected respectively.

* Private procs can only be called by things of exactly the same type
* Protected procs can only be call by things of the same type or subtypes

Additionally, Private procs cannot be overridden.

### Private / Protected vars

Use the above definitions of VAR_PRIVATE and VAR_PROTECTED to declare vars as 
`SpacemanDMM_private`/`SpacemanDMM_protected`.
These function the same way as the proc versions.
```