### PR TITLE
Adds /sound/len var to dreamchecker

### DIFF
--- a/src/dreammaker/builtins.rs
+++ b/src/dreammaker/builtins.rs
@@ -803,6 +803,7 @@ pub fn register_builtins(tree: &mut ObjectTree) -> Result<(), DMError> {
         sound/var/y = int!(0);
         sound/var/z = int!(0);
         sound/var/falloff = int!(1);
+        sound/var/len;
         sound/New(file, repeat, wait, channel, volume);
 
         icon;


### PR DESCRIPTION
https://github.com/SpaceManiac/SpacemanDMM/pull/139

This is the length of a sound file in real world seconds, it's a built in dreammaker proc but iirc it doesn't have any documentation.