### PR TITLE
Fix incorrect location of ambiguous in warnings

### DIFF
--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -711,8 +711,8 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 self.visit_expression(location, condition, None);
             },
             Statement::If { arms, else_arm } => {
-                for &(ref condition, ref block) in arms.iter() {
-                    self.visit_expression(location, condition, None);
+                for (condition, ref block) in arms.iter() {
+                    self.visit_expression(condition.location, &condition.elem, None);
                     self.visit_block(block);
                 }
                 if let Some(else_arm) = else_arm {

--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -790,7 +790,7 @@ pub enum Statement {
         condition: Expression,
     },
     If {
-        arms: Vec<(Expression, Block)>,
+        arms: Vec<(Spanned<Expression>, Block)>,
         else_arm: Option<Block>
     },
     ForLoop {

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -1105,7 +1105,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
         if let Some(()) = self.exact_ident("if")? {
             // statement :: 'if' '(' expression ')' block ('else' 'if' '(' expression ')' block)* ('else' block)?
             require!(self.exact(Token::Punct(Punctuation::LParen)));
-            let expr = require!(self.expression());
+            let expr = Spanned::new(self.location(), require!(self.expression()));
             require!(self.exact(Token::Punct(Punctuation::RParen)));
             let block = require!(self.block(loop_ctx));
             let mut arms = vec![(expr, block)];
@@ -1115,7 +1115,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             while let Some(()) = self.exact_ident("else")? {
                 if let Some(()) = self.exact_ident("if")? {
                     require!(self.exact(Token::Punct(Punctuation::LParen)));
-                    let expr = require!(self.expression());
+                    let expr = Spanned::new(self.location(), require!(self.expression()));
                     require!(self.exact(Token::Punct(Punctuation::RParen)));
                     let block = require!(self.block(loop_ctx));
                     arms.push((expr, block));

--- a/src/langserver/find_references.rs
+++ b/src/langserver/find_references.rs
@@ -205,8 +205,8 @@ impl<'o> WalkProc<'o> {
                 self.visit_expression(location, condition, None);
             },
             Statement::If { arms, else_arm } => {
-                for &(ref condition, ref block) in arms.iter() {
-                    self.visit_expression(location, condition, None);
+                for (condition, ref block) in arms.iter() {
+                    self.visit_expression(condition.location, &condition.elem, None);
                     self.visit_block(block);
                 }
                 if let Some(else_arm) = else_arm {


### PR DESCRIPTION
mve:

```dm
/mob/proc/foo()
	var/list/bar = list()
	if(!bar)
		return
	else if(bar && "foo" in bar)
		return
```