### PR TITLE
Add off-by-default lint to forbid relative pathing

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -67,6 +67,15 @@ The `[langserver]` section has the following options:
 
 * `dreamchecker` - Set to `true` to run dreamchecker within the language server.
 
+### Code standards
+
+These are extremely opinionated lint warnings and as such default to disabled
+
+The `[code_standards]` section has the following options:
+
+* `disallow_relative_proc_definitions` - Raised on relative pathed proc definitions
+* `disallow_relative_type_definitions` - Raised on relative pathed subtype defintions
+
 ## Example
 
 ```toml

--- a/src/dreammaker/config.rs
+++ b/src/dreammaker/config.rs
@@ -16,6 +16,7 @@ pub struct Config {
     display: WarningDisplay,
     pub langserver: Langserver,
     diagnostics: HashMap<String, WarningLevel>,
+    code_standards: CodeStandards,
 }
 
 #[derive(Deserialize, Default, Debug, Clone)]
@@ -28,6 +29,14 @@ pub struct WarningDisplay {
 pub struct Langserver {
     pub dreamchecker: bool,
 }
+
+#[derive(Deserialize, Default, Debug, Clone)]
+pub struct CodeStandards {
+    #[serde(default)]
+    pub disallow_relative_proc_definitions: bool,
+    pub disallow_relative_type_definitions: bool,
+}
+
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 #[serde(rename_all(deserialize = "lowercase"))]
@@ -73,6 +82,10 @@ impl Config {
 
     pub fn registerable_error(&self, error: &DMError) -> bool {
         self.display.error_level.applies_to(error.severity())
+    }
+
+    pub fn code_standards(&self) -> &CodeStandards {
+        &self.code_standards
     }
 }
 

--- a/src/dreammaker/config.rs
+++ b/src/dreammaker/config.rs
@@ -16,7 +16,7 @@ pub struct Config {
     display: WarningDisplay,
     pub langserver: Langserver,
     diagnostics: HashMap<String, WarningLevel>,
-    code_standards: CodeStandards,
+    pub code_standards: CodeStandards,
 }
 
 #[derive(Deserialize, Default, Debug, Clone)]
@@ -31,8 +31,8 @@ pub struct Langserver {
 }
 
 #[derive(Deserialize, Default, Debug, Clone)]
+#[serde(default)]
 pub struct CodeStandards {
-    #[serde(default)]
     pub disallow_relative_proc_definitions: bool,
     pub disallow_relative_type_definitions: bool,
 }
@@ -82,10 +82,6 @@ impl Config {
 
     pub fn registerable_error(&self, error: &DMError) -> bool {
         self.display.error_level.applies_to(error.severity())
-    }
-
-    pub fn code_standards(&self) -> &CodeStandards {
-        &self.code_standards
     }
 }
 

--- a/src/dreammaker/objtree.rs
+++ b/src/dreammaker/objtree.rs
@@ -1014,7 +1014,8 @@ impl ObjectTree {
             elems.len() + 1,
             Default::default(),
             Default::default(),
-        ).and(Ok(()))
+        )?;
+        Ok(())
     }
 
     // an entry which may be anything depending on the path
@@ -1028,7 +1029,8 @@ impl ObjectTree {
     ) -> Result<EntryType, DMError> {
         let (parent, child) = self.get_from_path(location, &mut path, len)?;
         if is_var_decl(child) {
-            self.register_var(location, parent, "var", path, comment, suffix).and(Ok(EntryType::VarDecl))
+            self.register_var(location, parent, "var", path, comment, suffix)?;
+            Ok(EntryType::VarDecl)
         } else if is_proc_decl(child) {
             Ok(EntryType::ProcDecl)
             // proc{} block, children will be procs

--- a/src/dreammaker/objtree.rs
+++ b/src/dreammaker/objtree.rs
@@ -646,6 +646,12 @@ impl Default for ObjectTree {
     }
 }
 
+pub enum EntryType {
+    ProcDecl,
+    Subtype,
+    VarDecl,
+}
+
 impl ObjectTree {
     pub fn with_builtins() -> ObjectTree {
         let mut objtree = ObjectTree::default();
@@ -1008,7 +1014,7 @@ impl ObjectTree {
             elems.len() + 1,
             Default::default(),
             Default::default(),
-        )
+        ).and(Ok(()))
     }
 
     // an entry which may be anything depending on the path
@@ -1019,17 +1025,18 @@ impl ObjectTree {
         len: usize,
         comment: DocCollection,
         suffix: VarSuffix,
-    ) -> Result<(), DMError> {
+    ) -> Result<EntryType, DMError> {
         let (parent, child) = self.get_from_path(location, &mut path, len)?;
         if is_var_decl(child) {
-            self.register_var(location, parent, "var", path, comment, suffix)?;
+            self.register_var(location, parent, "var", path, comment, suffix).and(Ok(EntryType::VarDecl))
         } else if is_proc_decl(child) {
+            Ok(EntryType::ProcDecl)
             // proc{} block, children will be procs
         } else {
             let idx = self.subtype_or_add(location, parent, child, len);
             self.graph.node_weight_mut(idx).unwrap().docs.extend(comment);
+            Ok(EntryType::Subtype)
         }
-        Ok(())
     }
 
     pub(crate) fn add_builtin_var(

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -799,7 +799,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 // `thing{` - block
                 match self.tree.add_entry(self.location, new_stack.iter(), new_stack.len(), Default::default(), var_suffix) {
                     Ok(EntryType::Subtype) => {
-                        if !absolute && self.context.config().code_standards().disallow_relative_type_definitions {
+                        if !absolute && self.context.config().code_standards.disallow_relative_type_definitions {
                             DMError::new(self.location, "relatively pathed type defined here")
                                 .set_severity(Severity::Warning)
                                 .register(self.context);
@@ -900,7 +900,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                             dest.insert(entry_start..body_start, Annotation::ProcHeader(new_stack.to_vec(), idx));
                             dest.insert(body_start..self.location, Annotation::ProcBody(new_stack.to_vec(), idx));
                         }
-                        if !absolute && self.context.config().code_standards().disallow_relative_proc_definitions {
+                        if !absolute && self.context.config().code_standards.disallow_relative_proc_definitions {
                             DMError::new(location, "relatively pathed proc defined here")
                                 .set_severity(Severity::Warning)
                                 .register(self.context);


### PR DESCRIPTION
Closes #148

This detects type definitions without a leading `/` as relative though.