### PR TITLE
Fixes ';' in proc args causing parse failure

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -54,6 +54,7 @@ Raised by Parser:
 
 * `var_in_proc_parameter` - Raised where `var/` is used in proc arguments
 * `static_in_proc_parameter` - Raised where `static/` is used in proc arguments
+* `semicolon_in_proc_parameter` - Raised where `;` is used in proc arguments
 * `in_precedes_as` - Raised where `input()` calls are using `as` after `in` which DM silently ignores
 * `tmp_no_effect` - Raised where local vars are defined as `tmp` which has no effect
 * `final_no_effect` - Raised where local vars are defined as `SpacemanDMM_final` which has no effect

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -980,6 +980,15 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             None
         };
         let (input_type, in_list) = require!(self.input_specifier());
+
+        // Allow a trailing `;` since BYOND accepts it, but this is dumb
+        if let Some(()) = self.exact(Punct(Semicolon))? {
+            DMError::new(self.updated_location(), "Extraneous ';' in proc parameter")
+                .set_severity(Severity::Warning)
+                .with_errortype("semicolon_in_proc_parameter")
+                .register(self.context);
+        }
+
         success(Parameter {
             var_type,
             name,

--- a/src/dreammaker/tests/ast_tests.rs
+++ b/src/dreammaker/tests/ast_tests.rs
@@ -1,0 +1,34 @@
+extern crate dreammaker as dm;
+
+use dm::*;
+use dm::preprocessor::Preprocessor;
+use dm::objtree::ObjectTree;
+
+fn with_code<F: FnOnce(Context, ObjectTree)>(code: &'static str, f: F) {
+    let context = Context::default();
+    let path = std::path::PathBuf::from(r"test.dm");
+    let pp = Preprocessor::from_buffer(&context, path, code.trim());
+    let indents = indents::IndentProcessor::new(&context, pp);
+    let mut parser = parser::Parser::new(&context, indents);
+    parser.enable_procs();
+    let _tree = parser.parse_object_tree();
+
+    f(context, _tree)
+}
+
+#[test]
+fn check_semicolon_in_proc_parameters() {
+    with_code("
+#define DEF1 0x01;
+#define DEF2 \"asdf\" as text;
+
+/proc/fuck(foo = DEF1, bar = DEF2, anotherarg = 1)
+", |context, _| {
+        let errors = context.errors();
+        assert_eq!(errors.len(), 2);
+
+        for error in errors.into_iter() {
+            assert_eq!(error.errortype().expect("No errortype set!"), "semicolon_in_proc_parameter");
+        }
+    });
+}

--- a/src/dreammaker/tests/ast_tests.rs
+++ b/src/dreammaker/tests/ast_tests.rs
@@ -22,7 +22,7 @@ fn check_semicolon_in_proc_parameters() {
 #define DEF1 0x01;
 #define DEF2 \"asdf\" as text;
 
-/proc/fuck(foo = DEF1, bar = DEF2, anotherarg = 1)
+/proc/darn(foo = DEF1, bar = DEF2, anotherarg = 1)
 ", |context, _| {
         let errors = context.errors();
         assert_eq!(errors.len(), 2);


### PR DESCRIPTION
Optionally allow trailing `;`s after the expression in proc arguments. Emit a warning when doing so.

Added ast_tests.

Fixes #172