### PR TITLE
Adds the PASS_MOUSE flag to builtins

### DIFF
--- a/src/dreammaker/builtins.rs
+++ b/src/dreammaker/builtins.rs
@@ -96,6 +96,7 @@ pub fn default_defines(defines: &mut DefineMap) {
         PLANE_MASTER = Int(128);
         TILE_BOUND = Int(256);
         PIXEL_SCALE = Int(512);
+        PASS_MOUSE = Int(1024);
 
         CONTROL_FREAK_ALL = Int(1);
         CONTROL_FREAK_SKIN = Int(2);


### PR DESCRIPTION
Introduced in 513.

see: http://www.byond.com/docs/ref/#/atom/var/appearance_flags

Fixes #194 