### PR TITLE
Populate errortype on more errors.

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -43,9 +43,12 @@ Raised by DreamChecker:
 * `no_typehint_implicit_new` - Raised on the use of `new` where no typehint is avaliable
 * `field_access_static_type` - Raised on using `.field_name` on a variable with no typehint
 * `proc_call_static_type` - Raised on using `.proc_name()` on a variable with no typehint
+* `proc_has_no_parent` - Raised on calling `..()` in a proc with no parent.
 * `no_operator_overload` - Raised on using a unary operator on a non-primative that doesn't define it's own override, eg `somemob++`
+* `unreachable_code` - Raised on finding code that can never be executed
 * `control_condition_static` - Raised on a control condition such as `if`/`while` having a static condition such as `1` or `"string"`
 * `if_condition_determinate` - Raised on if condition being always true or always false
+* `loop_condition_determinate` - Raised on loop condition such as in `for` being always true or always false
 
 Raised by Lexer:
 

--- a/src/dreamchecker/tests/branch_eval_tests.rs
+++ b/src/dreamchecker/tests/branch_eval_tests.rs
@@ -72,3 +72,24 @@ fn do_while() {
 "##.trim();
     check_errors_match(code, DO_WHILE_ERRORS);
 }
+
+pub const FOR_LOOP_CONDITION_ERRORS: &[(u32, u16, &str)] = &[
+    (2, 5, "loop condition is always true"),
+    (2, 5, "control flow condition is a static term"),
+    (4, 5, "control flow condition is a constant evalutation"),
+];
+
+#[test]
+fn for_loop_condition() {
+    let code = r##"
+/proc/test()
+    for(var/x = 0; 1; x++)
+        break
+    for(var/y = 0; 5 <= 7; y++)
+        break
+    for(var/z = 1; z <= 6; z++) // Legit, should have no error
+        break
+    return
+"##.trim();
+    check_errors_match(code, FOR_LOOP_CONDITION_ERRORS);
+}

--- a/src/dreamchecker/tests/proc_tests.rs
+++ b/src/dreamchecker/tests/proc_tests.rs
@@ -1,0 +1,18 @@
+
+extern crate dreamchecker as dc;
+
+use dc::test_helpers::check_errors_match;
+
+pub const NO_PARENT_ERRORS: &[(u32, u16, &str)] = &[
+    (2, 5, "proc has no parent: /mob/proc/test"),
+];
+
+#[test]
+fn no_parent() {
+    let code = r##"
+/mob/proc/test()
+    ..()
+    return
+"##.trim();
+    check_errors_match(code, NO_PARENT_ERRORS);
+}


### PR DESCRIPTION
- Added unreachable_code, proc_has_no_parent, and loop_condition_determinate error types.
- Added one use of control_condition_static where it was missing.
- Added unit tests covering some of the error conditions I looked at while adding these.

This is convenient for me when working on older codebases where I want to categorize and prioritize the types of linting errors to fix.  In addition to the ones I wanted, @spookydonut 's code inspired a few additional ones to add.
Plus I figure more unit test coverage is always helpful.