### PR TITLE
Adds missing filter flags for the outline filter.

### DIFF
--- a/src/dreammaker/builtins.rs
+++ b/src/dreammaker/builtins.rs
@@ -328,6 +328,10 @@ pub fn register_builtins(tree: &mut ObjectTree) -> Result<(), DMError> {
         var/const/WAVE_SIDEWAYS = int!(1);
         var/const/WAVE_BOUNDED = int!(2);
 
+        // outline filter
+        var/const/OUTLINE_SHARP = int!(1);
+        var/const/OUTLINE_SQUARE = int!(2);
+
         // global procs
         proc/abs(A);
         proc/addtext(Arg1, Arg2/*, ...*/);


### PR DESCRIPTION
Fixes #205 
Tried to fix the issue I found last night in the same way that #165 added other filter flags, but that PR seemed to have forgotten to add the two outline flags.

I tested this locally and the error doesn't come up now so it does work.

Hopefully I did everything right, let me know if there's any issues.