### PR TITLE
Extend Capabilities of Hover Request / dm-langserver

### DIFF
--- a/src/dreammaker/annotation.rs
+++ b/src/dreammaker/annotation.rs
@@ -79,7 +79,7 @@ impl AnnotationTree {
     }
 
     pub fn get_location(&self, loc: Location) -> Iter {
-        self.tree.range(range(loc.pred(), loc))
+        self.tree.range(range(loc, loc))
     }
 
     pub fn get_range(&self, place: std::ops::Range<Location>) -> Iter {

--- a/src/dreammaker/annotation.rs
+++ b/src/dreammaker/annotation.rs
@@ -79,7 +79,7 @@ impl AnnotationTree {
     }
 
     pub fn get_location(&self, loc: Location) -> Iter {
-        self.tree.range(range(loc, loc))
+        self.tree.range(range(loc.pred(), loc))
     }
 
     pub fn get_range(&self, place: std::ops::Range<Location>) -> Iter {

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -792,11 +792,15 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 let (docs, expression) = require!(self.doc_comment(|this| {
                     let expr = require!(this.expression());
                     let _ = require!(this.input_specifier());
+
+                    // We have to annotate prior to consuming the statement terminator, as we
+                    // will otherwise consume following whitespace resulting in a bad annotation range
+                    let node = this.tree[current].path.to_owned();
+                    this.annotate(entry_start, || Annotation::Variable(reconstruct_path(&node, proc_kind, var_type.as_ref(), last_part)));
+
+                    require!(this.statement_terminator());
                     success(expr)
                 }));
-
-                let node = self.tree[current].path.to_owned();
-                self.annotate(entry_start, || Annotation::Variable(reconstruct_path(&node, proc_kind, var_type.as_ref(), last_part)));
 
                 if let Some(mut var_type) = var_type {
                     var_type.suffix(&var_suffix);

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -786,11 +786,12 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             Punct(Assign) => {
                 // `something=` - var
                 let location = self.location;
+
                 // kind of goofy, but allows "enclosing" doc comments at the end of the line
+                // translators note: this allows comments of the form ``//! blah`` at the end of the line
                 let (docs, expression) = require!(self.doc_comment(|this| {
                     let expr = require!(this.expression());
                     let _ = require!(this.input_specifier());
-                    require!(this.statement_terminator());
                     success(expr)
                 }));
 

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -1118,6 +1118,7 @@ handle_method_call! {
 
                     let mut infos = VecDeque::new();
                     let mut next = Some(current);
+                    let mut docstring : Option<String> = None;
                     while let Some(current) = next {
                         if let Some(var) = current.vars.get(last) {
                             let constant = if let Some(ref constant) = var.value.constant {
@@ -1161,11 +1162,17 @@ handle_method_call! {
                                 declaration.push_str("**");
                                 infos.push_front(declaration);
                             }
+                            if docstring == None && !var.value.docs.is_empty() {
+                                docstring = Some(var.value.docs.text());
+                            }
                         }
                         next = current.parent_type();
                     }
                     if !infos.is_empty() {
                         results.push(infos.into_iter().collect::<Vec<_>>().join("\n\n"));
+                    }
+                    if let Some(ds) = docstring {
+                        results.push(ds);
                     }
                 }
                 Annotation::ProcHeader(path, _idx) if !path.is_empty() => {
@@ -1185,6 +1192,7 @@ handle_method_call! {
                     // the last proc for each type
                     let mut infos = VecDeque::new();
                     let mut next = Some(current);
+                    let mut docstring : Option<String> = None;
                     while let Some(current) = next {
                         if let Some(proc) = current.procs.get(last) {
                             let path = if current.path.is_empty() {
@@ -1214,11 +1222,18 @@ handle_method_call! {
                                 declaration.push_str("**");
                                 infos.push_front(declaration);
                             }
+
+                            if docstring == None && !proc_value.docs.is_empty() {
+                                docstring = Some(proc_value.docs.text());
+                            }
                         }
                         next = current.parent_type();
                     }
                     if !infos.is_empty() {
                         results.push(infos.into_iter().collect::<Vec<_>>().join("\n\n"));
+                    }
+                    if let Some(ds) = docstring {
+                        results.push(ds);
                     }
                 }
                 _ => {}

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -1162,7 +1162,7 @@ handle_method_call! {
                                 declaration.push_str("**");
                                 infos.push_front(declaration);
                             }
-                            if docstring == None && !var.value.docs.is_empty() {
+                            if !var.value.docs.is_empty() {
                                 docstring = Some(var.value.docs.text());
                             }
                         }
@@ -1223,7 +1223,7 @@ handle_method_call! {
                                 infos.push_front(declaration);
                             }
 
-                            if docstring == None && !proc_value.docs.is_empty() {
+                            if !proc_value.docs.is_empty() {
                                 docstring = Some(proc_value.docs.text());
                             }
                         }

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -840,11 +840,11 @@ impl<'a> Engine<'a> {
         Ok(symbol_id)
     }
 
-    fn construct_proc_hover(&self, proc_name : &str, mut provided_tok : Option<TypeRef>, scoped : bool) -> Result<Vec<String>, jsonrpc::Error> {
+    fn construct_proc_hover(&self, proc_name: &str, mut provided_tok: Option<TypeRef>, scoped: bool) -> Result<Vec<String>, jsonrpc::Error> {
         let mut results = Vec::new();
         let mut proclink  = String::new();
         let mut defstring = String::new();
-        let mut docstring : Option<String> = None;
+        let mut docstring: Option<String> = None;
         while let Some(ty) = provided_tok {
             if let Some(proc) = ty.procs.get(proc_name) {
                 let proc_value = proc.main_value();
@@ -884,8 +884,7 @@ impl<'a> Engine<'a> {
 
             if scoped {
                 provided_tok = ty.parent_type_without_root();
-            }
-            else {
+            } else {
                 provided_tok = ty.parent_type();
             }
         }
@@ -897,10 +896,10 @@ impl<'a> Engine<'a> {
         Ok(results)
     }
 
-    fn construct_var_hover(&self, var_name : &str, mut provided_tok : Option<TypeRef>, scoped : bool) -> Result<Vec<String>, jsonrpc::Error> {
+    fn construct_var_hover(&self, var_name: &str, mut provided_tok: Option<TypeRef>, scoped: bool) -> Result<Vec<String>, jsonrpc::Error> {
         let mut results = Vec::new();
         let mut infos = String::new();
-        let mut docstring : Option<String> = None;
+        let mut docstring: Option<String> = None;
         while let Some(ty) = provided_tok {
             if let Some(var) = ty.vars.get(var_name) {
                 if let Some(ref decl) = var.declaration {
@@ -922,8 +921,7 @@ impl<'a> Engine<'a> {
 
             if scoped {
                 provided_tok = ty.parent_type_without_root();
-            }
-            else {
+            } else {
                 provided_tok = ty.parent_type();
             }
         }
@@ -1217,7 +1215,7 @@ handle_method_call! {
 
                     let mut infos = VecDeque::new();
                     let mut next = Some(current);
-                    let mut docstring : Option<String> = None;
+                    let mut docstring: Option<String> = None;
                     while let Some(current) = next {
                         if let Some(var) = current.vars.get(last) {
                             let constant = if let Some(ref constant) = var.value.constant {
@@ -1264,7 +1262,7 @@ handle_method_call! {
                     // the last proc for each type
                     let mut infos = VecDeque::new();
                     let mut next = Some(current);
-                    let mut docstring : Option<String> = None;
+                    let mut docstring: Option<String> = None;
                     while let Some(current) = next {
                         if let Some(proc) = current.procs.get(last) {
                             let path = if current.path.is_empty() {

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -1176,7 +1176,7 @@ handle_method_call! {
                                 &current.path
                             };
                             let proc_value = proc.main_value();
-                            let mut message = format!("[{}]({})  \n{}(", path, self.location_link(proc_value.location)?, last);
+                            let mut message = format!("[{}]({})  \n```dm\n{}(", path, self.location_link(proc_value.location)?, last);
                             let mut first = true;
                             for each in proc_value.parameters.iter() {
                                 use std::fmt::Write;
@@ -1187,15 +1187,10 @@ handle_method_call! {
                                 }
                                 let _ = write!(message, "{}", each);
                             }
-                            message.push_str(")");
+                            message.push_str(")\n```");
                             infos.push_front(message);
                             if let Some(ref decl) = proc.declaration {
-                                let mut declaration = String::new();
-                                declaration.push_str(decl.kind.name());
-                                declaration.push_str("/**");
-                                declaration.push_str(last);
-                                declaration.push_str("**");
-                                infos.push_front(declaration);
+                                infos.push_front(format!("```dm\n{}/{}\n```", decl.kind.name(), last));
                             }
 
                             if !proc_value.docs.is_empty() {

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -1301,7 +1301,7 @@ handle_method_call! {
                         results.push(ds);
                     }
                 }
-                Annotation::UnscopedVar(var_name) if symbol_id != None => {
+                Annotation::UnscopedVar(var_name) if symbol_id.is_some() => {
                     let (ty, proc_name) = self.find_type_context(&iter);
                     match self.find_unscoped_var(&iter, ty, proc_name, var_name) {
                         UnscopedVar::Variable { ty, .. } => {
@@ -1312,16 +1312,16 @@ handle_method_call! {
                         _ => {}
                     }
                 }
-                Annotation::UnscopedCall(proc_name) if symbol_id != None => {
+                Annotation::UnscopedCall(proc_name) if symbol_id.is_some() => {
                     let (ty, _) = self.find_type_context(&iter);
                     let next = ty.or(Some(self.objtree.root()));
                     results.append(&mut self.construct_proc_hover(proc_name, next, false)?);
                 }
-                Annotation::ScopedCall(priors, proc_name) if symbol_id != None => {
+                Annotation::ScopedCall(priors, proc_name) if symbol_id.is_some() => {
                     let next = self.find_scoped_type(&iter, priors);
                     results.append(&mut self.construct_proc_hover(proc_name, next, true)?);
                 }
-                Annotation::ScopedVar(priors, var_name) if symbol_id != None => {
+                Annotation::ScopedVar(priors, var_name) if symbol_id.is_some() => {
                     let next = self.find_scoped_type(&iter, priors);
                     results.append(&mut self.construct_var_hover(var_name, next, true)?);
                 }

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -1124,7 +1124,7 @@ handle_method_call! {
                     while let Some(current) = next {
                         if let Some(var) = current.vars.get(last) {
                             let constant = if let Some(ref constant) = var.value.constant {
-                                format!("  \n= `{}`", constant)
+                                format!("\n```dm\n= {}\n```", constant)
                             } else {
                                 String::new()
                             };
@@ -1135,34 +1135,7 @@ handle_method_call! {
                             };
                             infos.push_front(format!("[{}]({}){}", path, self.location_link(var.value.location)?, constant));
                             if let Some(ref decl) = var.declaration {
-                                let mut declaration = String::new();
-                                declaration.push_str("var");
-                                if decl.var_type.flags.is_static() {
-                                    declaration.push_str("/static");
-                                }
-                                if decl.var_type.flags.is_const() {
-                                    declaration.push_str("/const");
-                                }
-                                if decl.var_type.flags.is_tmp() {
-                                    declaration.push_str("/tmp");
-                                }
-                                if decl.var_type.flags.is_final() {
-                                    declaration.push_str("/SpacemanDMM_final");
-                                }
-                                if decl.var_type.flags.is_private() {
-                                    declaration.push_str("/SpacemanDMM_private");
-                                }
-                                if decl.var_type.flags.is_protected() {
-                                    declaration.push_str("/SpacemanDMM_protected");
-                                }
-                                for bit in decl.var_type.type_path.iter() {
-                                    declaration.push('/');
-                                    declaration.push_str(&bit);
-                                }
-                                declaration.push_str("/**");
-                                declaration.push_str(last);
-                                declaration.push_str("**");
-                                infos.push_front(declaration);
+                                infos.push_front(format!("```dm\nvar/{}{}\n```", decl.var_type, last));
                             }
                             if !var.value.docs.is_empty() {
                                 docstring = Some(var.value.docs.text());
@@ -1260,34 +1233,7 @@ handle_method_call! {
                                             infos.push_str(format!("[{}]({})\n", path, self.location_link(var.value.location)?).as_str());
 
                                             // Next toss on the declaration itself
-                                            let mut declaration = String::new();
-                                            declaration.push_str("```dm\nvar");
-                                            if decl.var_type.flags.is_static() {
-                                                declaration.push_str("/static");
-                                            }
-                                            if decl.var_type.flags.is_const() {
-                                                declaration.push_str("/const");
-                                            }
-                                            if decl.var_type.flags.is_tmp() {
-                                                declaration.push_str("/tmp");
-                                            }
-                                            if decl.var_type.flags.is_final() {
-                                                declaration.push_str("/SpacemanDMM_final");
-                                            }
-                                            if decl.var_type.flags.is_private() {
-                                                declaration.push_str("/SpacemanDMM_private");
-                                            }
-                                            if decl.var_type.flags.is_protected() {
-                                                declaration.push_str("/SpacemanDMM_protected");
-                                            }
-                                            for bit in decl.var_type.type_path.iter() {
-                                                declaration.push('/');
-                                                declaration.push_str(&bit);
-                                            }
-                                            declaration.push_str("/");
-                                            declaration.push_str(var_name);
-                                            declaration.push_str("\n```");
-                                            infos += declaration.as_str();
+                                            infos.push_str(format!("```dm\nvar/{}{}\n```", decl.var_type, var_name).as_str());
                                         }
                                         if !var.value.docs.is_empty() {
                                             docstring = Some(var.value.docs.text());

--- a/src/langserver/main.rs
+++ b/src/langserver/main.rs
@@ -852,12 +852,7 @@ impl<'a> Engine<'a> {
                 // Because we need to find our declaration to get the declaration type, we partially
                 // form the markdown text to be used once the proc's declaration is reached
                 if defstring.is_empty() {
-                    let path = if ty.path.is_empty() {
-                        "(global)"
-                    } else {
-                        &ty.path
-                    };
-                    proclink = format!("[{}]({})", path, self.location_link(proc_value.location)?);
+                    proclink = format!("[{}]({})", ty.pretty_path(), self.location_link(proc_value.location)?);
                     let mut message = format!("{}(", proc_name);
                     let mut first = true;
                     for each in proc_value.parameters.iter() {
@@ -904,12 +899,7 @@ impl<'a> Engine<'a> {
             if let Some(var) = ty.vars.get(var_name) {
                 if let Some(ref decl) = var.declaration {
                     // First get the path of the type containing the declaration
-                    let path = if ty.path.is_empty() {
-                        "(global)"
-                    } else {
-                        &ty.path
-                    };
-                    infos.push_str(format!("[{}]({})\n", path, self.location_link(var.value.location)?).as_str());
+                    infos.push_str(format!("[{}]({})\n", ty.pretty_path(), self.location_link(var.value.location)?).as_str());
 
                     // Next toss on the declaration itself
                     infos.push_str(format!("```dm\nvar/{}{}\n```", decl.var_type, var_name).as_str());
@@ -1223,12 +1213,7 @@ handle_method_call! {
                             } else {
                                 String::new()
                             };
-                            let path = if current.path.is_empty() {
-                                "(global)"
-                            } else {
-                                &current.path
-                            };
-                            infos.push_front(format!("[{}]({}){}", path, self.location_link(var.value.location)?, constant));
+                            infos.push_front(format!("[{}]({}){}", current.pretty_path(), self.location_link(var.value.location)?, constant));
                             if let Some(ref decl) = var.declaration {
                                 infos.push_front(format!("```dm\nvar/{}{}\n```", decl.var_type, last));
                             }
@@ -1265,13 +1250,8 @@ handle_method_call! {
                     let mut docstring: Option<String> = None;
                     while let Some(current) = next {
                         if let Some(proc) = current.procs.get(last) {
-                            let path = if current.path.is_empty() {
-                                "(global)"
-                            } else {
-                                &current.path
-                            };
                             let proc_value = proc.main_value();
-                            let mut message = format!("[{}]({})  \n```dm\n{}(", path, self.location_link(proc_value.location)?, last);
+                            let mut message = format!("[{}]({})  \n```dm\n{}(", current.pretty_path(), self.location_link(proc_value.location)?, last);
                             let mut first = true;
                             for each in proc_value.parameters.iter() {
                                 use std::fmt::Write;


### PR DESCRIPTION
## Changelog
- Added hover handling for ScopedVar, UnscopedVar, ScopedProc, UnscopedProc
- Improved handling of existing hovers, adding ``dm`` lang blocks to the hovers where appropriate
- Added documentation to all existing hovers when it is available
- Fixed bug with annotating Variables, which would lead to excessive whitespace being consumed

## Previews
### ProcHeader Hover
![image](https://user-images.githubusercontent.com/10467687/92317434-eb6c3b00-efd6-11ea-9a12-acbcf4a36d15.png)

### Variable Hover
![image](https://user-images.githubusercontent.com/10467687/92317450-0474ec00-efd7-11ea-8318-60598479c2b2.png)

### ScopedVar Hover
![image](https://user-images.githubusercontent.com/10467687/92317458-1b1b4300-efd7-11ea-8541-4bbb4a3ff630.png)

### UnscopedVar Hover
![image](https://user-images.githubusercontent.com/10467687/92317462-21a9ba80-efd7-11ea-86f2-2513039a77ef.png)

### ScopedCall Hover
![image](https://user-images.githubusercontent.com/10467687/92317471-400fb600-efd7-11ea-993d-3804c17da766.png)

### UnscopedCall Hover
![image](https://user-images.githubusercontent.com/10467687/92317466-31c19a00-efd7-11ea-8304-cf53794e77f9.png)