### PR TITLE
Implements multiple suggested clippy lints

### DIFF
--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -553,11 +553,11 @@ pub enum Term {
 impl Term {
     pub fn is_static(&self) -> bool {
         matches!(self,
-            Term::Null      |
-            Term::Int(_)    |
-            Term::Float(_)  |
-            Term::String(_) |
-            Term::Prefab(_)
+            Term::Null
+            | Term::Int(_)
+            | Term::Float(_)
+            | Term::String(_)
+            | Term::Prefab(_)
         )
     }
 

--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -552,14 +552,13 @@ pub enum Term {
 
 impl Term {
     pub fn is_static(&self) -> bool {
-        return match self {
-            Term::Null |
-            Term::Int(_) |
-            Term::Float(_) |
+        matches!(self,
+            Term::Null      |
+            Term::Int(_)    |
+            Term::Float(_)  |
             Term::String(_) |
-            Term::Prefab(_) => true,
-            _ => false,
-        }
+            Term::Prefab(_)
+        )
     }
 
     pub fn is_truthy(&self) -> Option<bool> {
@@ -568,7 +567,7 @@ impl Term {
             Term::Null => Some(false),
             Term::Int(i) => Some(*i != 0),
             Term::Float(i) => Some(*i != 0f32),
-            Term::String(s) => Some(s.len() > 0),
+            Term::String(s) => Some(!s.is_empty()),
 
             // Paths/prefabs are truthy.
             Term::Prefab(_) => Some(true),
@@ -594,8 +593,8 @@ impl Term {
     }
 
     pub fn valid_for_range(&self, other: &Term, step: &Option<Expression>) -> Option<bool> {
-        if let &Term::Int(i) = self {
-            if let &Term::Int(o) = other {
+        if let Term::Int(i) = *self {
+            if let Term::Int(o) = *other {
                 // edge case
                 if i == 0 && o == 0 {
                     return Some(false)

--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -414,8 +414,8 @@ impl Expression {
                     BinaryOp::LessEq |
                     BinaryOp::GreaterEq |
                     BinaryOp::And |
-                    BinaryOp::Or => return true,
-                    _ => return false,
+                    BinaryOp::Or => true,
+                    _ => false,
                 }
             },
             _ => false,
@@ -435,9 +435,9 @@ impl Expression {
                     }
                 }
                 if negation {
-                    return Some(!truthy)
+                    Some(!truthy)
                 } else {
-                    return Some(truthy)
+                    Some(truthy)
                 }
             },
             Expression::BinaryOp { op, lhs, rhs } => {
@@ -447,7 +447,7 @@ impl Expression {
                 guard!(let Some(rhtruth) = rhs.is_truthy() else {
                     return None
                 });
-                return match op {
+                match op {
                     BinaryOp::And => Some(lhtruth && rhtruth),
                     BinaryOp::Or => Some(lhtruth || rhtruth),
                     _ => None,
@@ -468,9 +468,9 @@ impl Expression {
                     return None
                 });
                 if condtruth {
-                    return if_.is_truthy()
+                    if_.is_truthy()
                 } else {
-                    return else_.is_truthy()
+                    else_.is_truthy()
                 }
             }
         }

--- a/src/dreammaker/constants.rs
+++ b/src/dreammaker/constants.rs
@@ -70,7 +70,7 @@ pub enum Constant {
 // upstream properties without having to wrap/unwrap at all hours of the day.
 impl std::hash::Hash for Constant {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(&self).hash(state);
+        std::mem::discriminant(self).hash(state);
         match self {
             Constant::Null(p) => p.hash(state),
             Constant::New { type_, args } => (type_, args).hash(state),

--- a/src/dreammaker/constants.rs
+++ b/src/dreammaker/constants.rs
@@ -747,7 +747,7 @@ impl<'a> ConstantFolder<'a> {
                         return Err(self.error(format!("malformed rgb() call, must have 3 or 4 arguments and instead has {}", args.len())));
                     }
                     let mut result = String::with_capacity(7);
-                    result.push_str("#");
+                    result.push('#');
                     for each in args {
                         if let Some(i) = self.expr(each, None)?.to_int() {
                             let clamped = std::cmp::max(::std::cmp::min(i, 255), 0);

--- a/src/dreammaker/constants.rs
+++ b/src/dreammaker/constants.rs
@@ -147,10 +147,7 @@ impl Constant {
 
     #[inline]
     pub fn is_null(&self) -> bool {
-        match *self {
-            Constant::Null(_) => true,
-            _ => false,
-        }
+        matches!(*self, Constant::Null(_))
     }
 
     pub fn to_bool(&self) -> bool {

--- a/src/dreammaker/dmi.rs
+++ b/src/dreammaker/dmi.rs
@@ -51,13 +51,10 @@ impl Dir {
     }
 
     pub fn is_diagonal(self) -> bool {
-        match self {
-            Dir::North |
-            Dir::South |
-            Dir::East |
-            Dir::West => false,
-            _ => true
-        }
+        !matches!(self, Dir::North  |
+                        Dir::South  |
+                        Dir::East   |
+                        Dir::West)
     }
 
     pub fn flip(self) -> Dir {

--- a/src/dreammaker/dmi.rs
+++ b/src/dreammaker/dmi.rs
@@ -240,7 +240,7 @@ impl Metadata {
         for (key, value) in decoder.info_png().text_keys() {
             if key == b"Description" {
                 if let Ok(value) = std::str::from_utf8(value) {
-                    return Metadata::from_str(value);
+                    return Metadata::meta_from_str(value);
                 }
                 break;
             }
@@ -255,7 +255,7 @@ impl Metadata {
 
     /// Parse metadata from a `Description` string.
     #[inline]
-    pub fn from_str(data: &str) -> Metadata {
+    pub fn meta_from_str(data: &str) -> Metadata {
         parse_metadata(data)
     }
 

--- a/src/dreammaker/dmi.rs
+++ b/src/dreammaker/dmi.rs
@@ -51,10 +51,11 @@ impl Dir {
     }
 
     pub fn is_diagonal(self) -> bool {
-        !matches!(self, Dir::North  |
-                        Dir::South  |
-                        Dir::East   |
-                        Dir::West)
+        !matches!(self,
+            Dir::North
+            | Dir::South
+            | Dir::East
+            | Dir::West)
     }
 
     pub fn flip(self) -> Dir {

--- a/src/dreammaker/docs.rs
+++ b/src/dreammaker/docs.rs
@@ -39,15 +39,15 @@ impl DocCollection {
                         continue;
                     }
                     // block comments are always paragraphs
-                    output.push_str("\n");
+                    output.push('\n');
                     if simplify(&mut output, &each.text, '*') {
-                        output.push_str("\n");
+                        output.push('\n');
                     }
                 },
                 CommentKind::Line => {
                     // line comments are paragraphs only if there are blanks
                     line_comments.push_str(&each.text);
-                    line_comments.push_str("\n");
+                    line_comments.push('\n');
                 },
             }
         }
@@ -182,7 +182,7 @@ fn simplify(out: &mut String, text: &str, ignore_char: char) -> bool {
         }
         // ...but include them in the middle.
         for _ in 0..newlines {
-            out.push_str("\n");
+            out.push('\n');
         }
         out.push_str(&line[prefix_len..line.len() - suffix_len]);
         anything = true;

--- a/src/dreammaker/lexer.rs
+++ b/src/dreammaker/lexer.rs
@@ -313,13 +313,12 @@ impl Token {
 
     /// Check whether this token is whitespace.
     pub fn is_whitespace(&self) -> bool {
-        match *self {
-            Token::Punct(Punctuation::Tab) |
-            Token::Punct(Punctuation::Newline) |
-            Token::Punct(Punctuation::Space) |
-            Token::Eof => true,
-            _ => false
-        }
+        matches!(*self,
+            Token::Punct(Punctuation::Tab)      |
+            Token::Punct(Punctuation::Newline)  |
+            Token::Punct(Punctuation::Space)    |
+            Token::Eof
+        )
     }
 
     /// Check whether this token matches a given identifier.

--- a/src/dreammaker/lexer.rs
+++ b/src/dreammaker/lexer.rs
@@ -314,10 +314,10 @@ impl Token {
     /// Check whether this token is whitespace.
     pub fn is_whitespace(&self) -> bool {
         matches!(*self,
-            Token::Punct(Punctuation::Tab)      |
-            Token::Punct(Punctuation::Newline)  |
-            Token::Punct(Punctuation::Space)    |
-            Token::Eof
+            Token::Punct(Punctuation::Tab)
+            | Token::Punct(Punctuation::Newline)
+            | Token::Punct(Punctuation::Space)
+            | Token::Eof
         )
     }
 

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -227,10 +227,7 @@ oper_table! { BINARY_OPS;
 
 impl Strength {
     fn right_binding(self) -> bool {
-        match self {
-            Strength::Assign => true,
-            _ => false,
-        }
+        matches!(self, Strength::Assign)
     }
 }
 
@@ -367,7 +364,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
     pub fn parse_with_module_docs(mut self) -> (ObjectTree, BTreeMap<FileId, Vec<(u32, DocComment)>>) {
         self.tree.register_builtins();
         self.run();
-        let docs = std::mem::replace(&mut self.module_docs, Default::default());
+        let docs = std::mem::take(&mut self.module_docs);
         (self.finalize_object_tree(), docs)
     }
 
@@ -568,8 +565,8 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
     fn doc_comment<R, F: FnOnce(&mut Self) -> Status<R>>(&mut self, f: F) -> Status<(DocCollection, R)> {
         use std::mem::replace;
 
-        let enclosing = replace(&mut self.docs_enclosing, Default::default());
-        let mut docs = replace(&mut self.docs_following, Default::default());
+        let enclosing = std::mem::take(&mut self.docs_enclosing);
+        let mut docs = std::mem::take(&mut self.docs_following);
         self.in_docs += 1;
         let result = f(self);
         self.in_docs -= 1;

--- a/src/dreammaker/preprocessor.rs
+++ b/src/dreammaker/preprocessor.rs
@@ -306,10 +306,7 @@ impl<'ctx> IncludeStack<'ctx> {
     }
 
     fn in_expansion(&self) -> bool {
-        match self.stack.last() {
-            Some(Include::Expansion { .. }) => true,
-            _ => false,
-        }
+        matches!(self.stack.last(), Some(Include::Expansion { .. }))
     }
 }
 


### PR DESCRIPTION
These were the lints mostly:
* match_like_matches_macro
* mem_replace_with_default
* match_ref_pats
* single_char_push_str
* len_zero

There were also a few unnecessary return lints that popped up, but I'm not sure if you want to remove those.