### PR TITLE
Allow directive settings to use configs

### DIFF
--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -8,6 +8,7 @@ use dm::{Context, DMError, Location, Severity};
 use dm::objtree::{ObjectTree, TypeRef, ProcRef, Code};
 use dm::constants::{Constant, ConstFn};
 use dm::ast::*;
+use dm::config::*;
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
@@ -518,6 +519,22 @@ impl DMErrorExt for DMError {
     }
 }
 
+trait DirectiveFromConfig {
+    fn to_proc_directive(self, directive_string: &'static str) -> ProcDirective;
+}
+
+impl DirectiveFromConfig for MustCallParent {
+    fn to_proc_directive(self, directive_string: &'static str) -> ProcDirective {
+        ProcDirective {
+            directive: Default::default(),
+            directive_string,
+            can_be_disabled: self.can_be_disabled,
+            set_at_definition: self.set_at_definition,
+            can_be_global: self.can_be_global,
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct ViolatingProcs<'o> {
     violators: HashMap<ProcRef<'o>, Vec<(String, Location)>>,
@@ -584,7 +601,7 @@ impl<'o> AnalyzeObjectTree<'o> {
             context,
             objtree,
             return_type,
-            must_call_parent: ProcDirective::new("SpacemanDMM_should_call_parent", true, false, false),
+            must_call_parent: context.config().procdirective.must_call_parent.to_proc_directive("SpacemanDMM_should_call_parent"),
             must_not_override: ProcDirective::new("SpacemanDMM_should_not_override", false, false, false),
             private: ProcDirective::new("SpacemanDMM_private_proc", false, true, false),
             protected: ProcDirective::new("SpacemanDMM_protected_proc", false, true, false),

--- a/src/dreammaker/config.rs
+++ b/src/dreammaker/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     // tool-specific configuration
     pub langserver: Langserver,
     pub dmdoc: DMDoc,
+    pub procdirective: ProcDirectiveSection,
 }
 
 /// General error display options
@@ -185,4 +186,113 @@ impl From<toml::de::Error> for Error {
     fn from(err: toml::de::Error) -> Error {
         Error::Toml(err)
     }
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct ProcDirectiveSection {
+    pub must_call_parent: MustCallParent,
+    must_not_override: MustNotOverride,
+    private: PrivateDirective,
+    protected: ProtectedDirective,
+    must_not_sleep: MustNotSleep,
+    sleep_exempt: SleepExempt,
+    must_be_pure: MustBePure,
+    can_be_redefined: CanBeRedefined,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, Copy)]
+#[serde(default)]
+pub struct MustCallParent {
+    #[serde(default = "enable")]
+    pub can_be_disabled: bool,
+    #[serde(default = "disable")]
+    pub set_at_definition: bool,
+    #[serde(default = "disable")]
+    pub can_be_global: bool,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct MustNotOverride {
+    #[serde(default = "disable")]
+    can_be_disabled: bool,
+    #[serde(default = "disable")]
+    set_at_definition: bool,
+    #[serde(default = "disable")]
+    can_be_global: bool,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct PrivateDirective {
+    #[serde(default = "disable")]
+    can_be_disabled: bool,
+    #[serde(default = "enable")]
+    set_at_definition: bool,
+    #[serde(default = "disable")]
+    can_be_global: bool,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct ProtectedDirective {
+    #[serde(default = "disable")]
+    can_be_disabled: bool,
+    #[serde(default = "enable")]
+    set_at_definition: bool,
+    #[serde(default = "disable")]
+    can_be_global: bool,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct MustNotSleep {
+    #[serde(default = "disable")]
+    can_be_disabled: bool,
+    #[serde(default = "enable")]
+    set_at_definition: bool,
+    #[serde(default = "enable")]
+    can_be_global: bool,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct SleepExempt {
+    #[serde(default = "disable")]
+    can_be_disabled: bool,
+    #[serde(default = "enable")]
+    set_at_definition: bool,
+    #[serde(default = "enable")]
+    can_be_global: bool,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct MustBePure {
+    #[serde(default = "disable")]
+    can_be_disabled: bool,
+    #[serde(default = "enable")]
+    set_at_definition: bool,
+    #[serde(default = "enable")]
+    can_be_global: bool,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct CanBeRedefined {
+    #[serde(default = "disable")]
+    can_be_disabled: bool,
+    #[serde(default = "disable")]
+    set_at_definition: bool,
+    #[serde(default = "disable")]
+    can_be_global: bool,
+}
+
+fn enable() -> bool {
+    true
+}
+
+fn disable() -> bool {
+    false
 }


### PR DESCRIPTION
```
/mob/proc/foo()
    set SpacemanDMM_should_call_parent = TRUE
/mob/living/foo()
    set SpacemanDMM_should_call_parent = FALSE
```
```
[procdirective]

[procdirective.must_call_parent]
can_be_disabled = false
```
``` 
============================================================
Gathering proc settings...

test.dm, line 4, column 5:
warning: /mob/living/proc/foo sets SpacemanDMM_should_call_parent false, but it cannot be disabled.

============================================================
Analyzing proc bodies...

test.dm, line 3, column 16:
error: proc never calls parent, required by /mob/proc/foo
- 2:5: required by this must_call_parent annotation

Procs analyzed: 2. Errored: 0. Builtins: 324.
```

i dont know how to do this in a non-ass way yet