### PR TITLE
Detect unused typevars

### DIFF
--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -922,7 +922,7 @@ impl fmt::Display for VarTypeFlags {
 }
 
 /// A type which may be ascribed to a `var`.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Eq, Hash)]
 pub struct VarType {
     pub flags: VarTypeFlags,
     pub type_path: TreePath,

--- a/src/dreammaker/error.rs
+++ b/src/dreammaker/error.rs
@@ -255,7 +255,7 @@ impl Context {
 // Location handling
 
 /// File, line, and column information for an error.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Hash)]
 pub struct Location {
     /// The index into the file table.
     pub file: FileId,

--- a/src/dreammaker/objtree.rs
+++ b/src/dreammaker/objtree.rs
@@ -46,7 +46,7 @@ impl SymbolIdSource {
 
 pub type Vars = LinkedHashMap<String, Constant>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct VarDeclaration {
     pub var_type: VarType,
     pub location: Location,


### PR DESCRIPTION
This detects unused type vars but because of #219 it isn't working correctly

There's also no obvious way i can see to get the actual var name.