### PR TITLE
Add warning for `return x` in spawn context

### DIFF
--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -1281,6 +1281,11 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             },
             Statement::Return(Some(expr)) => {
                 // TODO: factor in the previous return type if there was one
+                if self.inside_newcontext > 0 {
+                    error(location, "returning a value in a spawn has no effect")
+                        .set_severity(Severity::Warning)
+                        .register(self.context);
+                }
                 let return_type = self.visit_expression(location, expr, None, local_vars);
                 local_vars.get_mut(".").unwrap().analysis = return_type;
                 return ControlFlow { returns: true, continues: false, breaks: false, fuzzy: false }


### PR DESCRIPTION
As far as I know doing `return something` in a `spawn` context is always equivalent to just returning without a value and as such it is probably a mistake so let's warn people about it.