### PR TITLE
Fixes var declaration location being wrong

### DIFF
--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -783,6 +783,8 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             Default::default()
         };
 
+        let old_location = self.location;
+
         // read the contents for real
         match self.next("contents")? {
             t @ Punct(LBrace) => {
@@ -807,7 +809,6 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             Punct(Assign) => {
                 // `something=` - var
                 handle_relative_type_error!();
-                let location = self.location;
 
                 // kind of goofy, but allows "enclosing" doc comments at the end of the line
                 // translators note: this allows comments of the form ``//! blah`` at the end of the line
@@ -826,9 +827,9 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
 
                 if let Some(mut var_type) = var_type {
                     var_type.suffix(&var_suffix);
-                    self.tree.declare_var(current, last_part, location, docs, var_type, Some(expression));
+                    self.tree.declare_var(current, last_part, old_location, docs, var_type, Some(expression));
                 } else {
-                    self.tree.override_var(current, last_part, location, docs, expression);
+                    self.tree.override_var(current, last_part, old_location, docs, expression);
                 }
 
                 SUCCESS


### PR DESCRIPTION
Fixes #219 .
It looks like this is caused by two separate issues. One is that `put_back` doesn't update `location` properly and the other is that in declarations with assignment the location used for var declaration is taken after parsing the `=`. This hopefully fixes both.

I checked that var declaration locations now seem to be correct, I just hope nothing relies on `put_back` not fixing location. Yell at me if I got something completely wrong here.