### PR TITLE
Auxtools update

### DIFF
--- a/src/langserver/debugger/auxtools.rs
+++ b/src/langserver/debugger/auxtools.rs
@@ -165,6 +165,27 @@ impl Auxtools {
         }
     }
 
+    pub fn disassemble(&mut self, path: &str, override_id: u32) -> Result<String, Box<dyn std::error::Error>> {
+        self.send_or_disconnect(Request::Disassemble(ProcRef {
+            path: path.to_owned(),
+            override_id,
+        }))?;
+
+        match self.read_response_or_disconnect()? {
+            Response::Disassemble(res) => Ok(res),
+            response => Err(Box::new(UnexpectedResponse::new("Disassemble", response))),
+        }
+    }
+
+    pub fn get_current_proc(&mut self, frame_id: u32) -> Result<Option<(String, u32)>, Box<dyn std::error::Error>> {
+        self.send_or_disconnect(Request::CurrentInstruction { frame_id })?;
+
+        match self.read_response_or_disconnect()? {
+            Response::CurrentInstruction(ins) => Ok(ins.map(|x| (x.proc.path, x.proc.override_id))),
+            response => Err(Box::new(UnexpectedResponse::new("CurrentInstruction", response))),
+        }
+    }
+
     pub fn get_line_number(&mut self, path: &str, override_id: u32, offset: u32) -> Result<Option<u32>, Box<dyn std::error::Error>> {
         self.send_or_disconnect(Request::LineNumber {
             proc: ProcRef {

--- a/src/langserver/debugger/auxtools.rs
+++ b/src/langserver/debugger/auxtools.rs
@@ -146,6 +146,16 @@ impl Auxtools {
         self.stream = StreamState::Disconnected;
     }
 
+    pub fn configured(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        debug_output!(in self.seq, "[auxtools] configured");
+        self.send_or_disconnect(Request::Configured)?;
+
+        match self.read_response_or_disconnect()? {
+            Response::Ack { .. } => Ok(()),
+            response => Err(Box::new(UnexpectedResponse::new("Ack", response))),
+        }
+    }
+
     pub fn get_line_number(&mut self, path: &str, override_id: u32, offset: u32) -> Result<Option<u32>, Box<dyn std::error::Error>> {
         self.send_or_disconnect(Request::LineNumber {
             proc: ProcRef {

--- a/src/langserver/debugger/auxtools.rs
+++ b/src/langserver/debugger/auxtools.rs
@@ -156,6 +156,15 @@ impl Auxtools {
         }
     }
 
+    pub fn get_stddef(&mut self) -> Result<Option<String>, Box<dyn std::error::Error>> {
+        self.send_or_disconnect(Request::StdDef)?;
+
+        match self.read_response_or_disconnect()? {
+            Response::StdDef(contents) => Ok(contents),
+            response => Err(Box::new(UnexpectedResponse::new("StdDef", response))),
+        }
+    }
+
     pub fn get_line_number(&mut self, path: &str, override_id: u32, offset: u32) -> Result<Option<u32>, Box<dyn std::error::Error>> {
         self.send_or_disconnect(Request::LineNumber {
             proc: ProcRef {

--- a/src/langserver/debugger/auxtools_types.rs
+++ b/src/langserver/debugger/auxtools_types.rs
@@ -9,6 +9,7 @@ pub const DEFAULT_PORT: u16 = 2448;
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Request {
     Disconnect,
+    Configured,
     BreakpointSet {
         instruction: InstructionRef,
     },

--- a/src/langserver/debugger/auxtools_types.rs
+++ b/src/langserver/debugger/auxtools_types.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_PORT: u16 = 2448;
 pub enum Request {
     Disconnect,
     Configured,
+    StdDef,
     BreakpointSet {
         instruction: InstructionRef,
     },
@@ -49,6 +50,7 @@ pub enum Request {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Response {
     Ack,
+    StdDef(Option<String>),
     BreakpointSet {
         result: BreakpointSetResult,
     },

--- a/src/langserver/debugger/auxtools_types.rs
+++ b/src/langserver/debugger/auxtools_types.rs
@@ -11,6 +11,10 @@ pub enum Request {
     Disconnect,
     Configured,
     StdDef,
+    Disassemble(ProcRef),
+    CurrentInstruction {
+        frame_id: u32,
+    },
     BreakpointSet {
         instruction: InstructionRef,
     },
@@ -51,6 +55,8 @@ pub enum Request {
 pub enum Response {
     Ack,
     StdDef(Option<String>),
+    Disassemble(String),
+    CurrentInstruction(Option<InstructionRef>),
     BreakpointSet {
         result: BreakpointSetResult,
     },

--- a/src/langserver/debugger/evaluate.rs
+++ b/src/langserver/debugger/evaluate.rs
@@ -46,7 +46,7 @@ impl Debugger {
 
             DebugClient::Auxtools(auxtools) => {
                 lazy_static! {
-                    static ref DISASSEMBLE_REGEX: Regex = Regex::new(r"^#dis(?:assemble)? (?P<path>[\w/\(\)]+) ?(?P<override>[0-9]*)$").unwrap();
+                    static ref DISASSEMBLE_REGEX: Regex = Regex::new(r"^#dis(?:assemble)? (?P<path>[^ ]+) ?(?P<override>[0-9]*)$").unwrap();
                 }
 
                 if input.starts_with("#help") {

--- a/src/langserver/debugger/evaluate.rs
+++ b/src/langserver/debugger/evaluate.rs
@@ -1,8 +1,15 @@
+use regex::Regex;
+use lazy_static;
+
 use super::dap_types::*;
 use super::*;
 
-const EVALUATE_HELP: &str = "
+const EXTOOLS_HELP: &str = "
 #dis, #disassemble: show disassembly for current stack frame";
+
+const AUXTOOLS_HELP: &str = "
+#dis, #disassemble: show disassembly for current stack frame
+#dis, #disassemble <proc path> <override id (optional)>: show disassembly for specified proc";
 
 impl Debugger {
     pub fn evaluate(
@@ -10,13 +17,14 @@ impl Debugger {
         params: EvaluateArguments,
     ) -> Result<EvaluateResponse, Box<dyn std::error::Error>> {
         let input = params.expression.trim_start();
-        if input.starts_with("#help") {
-            return Ok(EvaluateResponse::from(EVALUATE_HELP.trim()));
-        }
 
         match &mut self.client {
             DebugClient::Extools(extools) => {
                 let extools = extools.get()?;
+
+                if input.starts_with("#help") {
+                    return Ok(EvaluateResponse::from(EXTOOLS_HELP.trim()));
+                }
 
                 guard!(let Some(frame_id) = params.frameId else {
                     return Err(Box::new(GenericError("Must select a stack frame to evaluate in")));
@@ -36,7 +44,37 @@ impl Debugger {
                 }
             }
 
-            DebugClient::Auxtools(_) => {}
+            DebugClient::Auxtools(auxtools) => {
+                lazy_static! {
+                    static ref DISASSEMBLE_REGEX: Regex = Regex::new(r"^#dis(?:assemble)? (?P<path>[\w/]+) ?(?P<override>[0-9]*)$").unwrap();
+                }
+
+                if input.starts_with("#help") {
+                    return Ok(EvaluateResponse::from(AUXTOOLS_HELP.trim()));
+                }
+
+                if input == "#dis" || input == "#disassemble" {
+                    guard!(let Some(frame_id) = params.frameId else {
+                        return Err(Box::new(GenericError("Must select a stack frame to evaluate in")));
+                    });
+
+                    let (path, override_id) = auxtools.get_current_proc(frame_id as u32)?.ok_or_else(|| {
+                        Box::new(GenericError("Couldn't find current proc"))
+                    })?;
+
+                    return Ok(EvaluateResponse::from(auxtools.disassemble(&path, override_id)?));
+                }
+
+                if let Some(captures) = DISASSEMBLE_REGEX.captures(input) {
+                    let path = &captures["path"];
+                    let override_id = match captures.name("override").map(|x| x.as_str()) {
+                        Some(str) => str.parse::<u32>().unwrap_or(0),
+                        _ => 0,
+                    };
+
+                    return Ok(EvaluateResponse::from(auxtools.disassemble(path, override_id)?));
+                }
+            }
         }
 
         Err(Box::new(GenericError("Not yet implemented")))

--- a/src/langserver/debugger/evaluate.rs
+++ b/src/langserver/debugger/evaluate.rs
@@ -46,7 +46,7 @@ impl Debugger {
 
             DebugClient::Auxtools(auxtools) => {
                 lazy_static! {
-                    static ref DISASSEMBLE_REGEX: Regex = Regex::new(r"^#dis(?:assemble)? (?P<path>[\w/]+) ?(?P<override>[0-9]*)$").unwrap();
+                    static ref DISASSEMBLE_REGEX: Regex = Regex::new(r"^#dis(?:assemble)? (?P<path>[\w/\(\)]+) ?(?P<override>[0-9]*)$").unwrap();
                 }
 
                 if input.starts_with("#help") {

--- a/src/langserver/debugger/mod.rs
+++ b/src/langserver/debugger/mod.rs
@@ -504,7 +504,9 @@ handle_request! {
                 extools.configuration_done();
             }
 
-            DebugClient::Auxtools(_) => {}
+            DebugClient::Auxtools(auxtools) => {
+                auxtools.configured()?;
+            }
         }
     }
 

--- a/src/langserver/debugger/mod.rs
+++ b/src/langserver/debugger/mod.rs
@@ -505,6 +505,7 @@ handle_request! {
             }
 
             DebugClient::Auxtools(auxtools) => {
+                self.stddef_dm_info = auxtools.get_stddef()?.map(|x| StddefDmInfo::new(x));
                 auxtools.configured()?;
             }
         }


### PR DESCRIPTION
This fulfils some auxtool debugger requests you had.
Depends on: https://github.com/willox/auxtools/commit/b3fb2f7f325cea6a5709540c5fa1687d02d574d4.

1) All connection modes except for `BACKGROUND` wait for the DAP client to be configured before continuing.
2) stddef.dm contents are sent to the debug client
3) disassemble eval command works (with the added benefit of being able to disassemble procs that aren't currently running)

The updated auxtools also does some other stuff you wanted:
1) src/usr moved to arguments
2) your PR https://github.com/willox/auxtools/pull/11
3) arguments with no formal parameter in a proc that is being debugged should show up