### PR TITLE
Offload eval (disassemble/help commands) processing to auxtools

### DIFF
--- a/src/langserver/debugger/auxtools.rs
+++ b/src/langserver/debugger/auxtools.rs
@@ -165,15 +165,15 @@ impl Auxtools {
         }
     }
 
-    pub fn disassemble(&mut self, path: &str, override_id: u32) -> Result<String, Box<dyn std::error::Error>> {
-        self.send_or_disconnect(Request::Disassemble(ProcRef {
-            path: path.to_owned(),
-            override_id,
-        }))?;
+    pub fn eval(&mut self, frame_id: Option<u32>, command: &str) -> Result<String, Box<dyn std::error::Error>> {
+        self.send_or_disconnect(Request::Eval{
+            frame_id,
+            command: command.to_owned()
+        })?;
 
         match self.read_response_or_disconnect()? {
-            Response::Disassemble(res) => Ok(res),
-            response => Err(Box::new(UnexpectedResponse::new("Disassemble", response))),
+            Response::Eval(res) => Ok(res),
+            response => Err(Box::new(UnexpectedResponse::new("Eval", response))),
         }
     }
 

--- a/src/langserver/debugger/auxtools_types.rs
+++ b/src/langserver/debugger/auxtools_types.rs
@@ -11,7 +11,10 @@ pub enum Request {
     Disconnect,
     Configured,
     StdDef,
-    Disassemble(ProcRef),
+    Eval {
+        frame_id: Option<u32>,
+        command: String,
+    },
     CurrentInstruction {
         frame_id: u32,
     },
@@ -55,7 +58,7 @@ pub enum Request {
 pub enum Response {
     Ack,
     StdDef(Option<String>),
-    Disassemble(String),
+    Eval(String),
     CurrentInstruction(Option<InstructionRef>),
     BreakpointSet {
         result: BreakpointSetResult,

--- a/src/langserver/debugger/evaluate.rs
+++ b/src/langserver/debugger/evaluate.rs
@@ -38,14 +38,12 @@ impl Debugger {
             }
 
             DebugClient::Auxtools(auxtools) => {
-                if input.starts_with("#") {
-                    return Ok(EvaluateResponse::from(
-                        auxtools.eval(
-                            params.frameId.map(|x| x as u32),
-                            &input[1..]
-                        )?
-                    ));
-                }
+                return Ok(EvaluateResponse::from(
+                    auxtools.eval(
+                        params.frameId.map(|x| x as u32),
+                        input
+                    )?
+                ));
             }
         }
 

--- a/src/langserver/debugger/evaluate.rs
+++ b/src/langserver/debugger/evaluate.rs
@@ -1,15 +1,8 @@
-use regex::Regex;
-use lazy_static;
-
 use super::dap_types::*;
 use super::*;
 
 const EXTOOLS_HELP: &str = "
 #dis, #disassemble: show disassembly for current stack frame";
-
-const AUXTOOLS_HELP: &str = "
-#dis, #disassemble: show disassembly for current stack frame
-#dis, #disassemble <proc path> <override id (optional)>: show disassembly for specified proc";
 
 impl Debugger {
     pub fn evaluate(
@@ -45,34 +38,13 @@ impl Debugger {
             }
 
             DebugClient::Auxtools(auxtools) => {
-                lazy_static! {
-                    static ref DISASSEMBLE_REGEX: Regex = Regex::new(r"^#dis(?:assemble)? (?P<path>[^ ]+) ?(?P<override>[0-9]*)$").unwrap();
-                }
-
-                if input.starts_with("#help") {
-                    return Ok(EvaluateResponse::from(AUXTOOLS_HELP.trim()));
-                }
-
-                if input == "#dis" || input == "#disassemble" {
-                    guard!(let Some(frame_id) = params.frameId else {
-                        return Err(Box::new(GenericError("Must select a stack frame to evaluate in")));
-                    });
-
-                    let (path, override_id) = auxtools.get_current_proc(frame_id as u32)?.ok_or_else(|| {
-                        Box::new(GenericError("Couldn't find current proc"))
-                    })?;
-
-                    return Ok(EvaluateResponse::from(auxtools.disassemble(&path, override_id)?));
-                }
-
-                if let Some(captures) = DISASSEMBLE_REGEX.captures(input) {
-                    let path = &captures["path"];
-                    let override_id = match captures.name("override").map(|x| x.as_str()) {
-                        Some(str) => str.parse::<u32>().unwrap_or(0),
-                        _ => 0,
-                    };
-
-                    return Ok(EvaluateResponse::from(auxtools.disassemble(path, override_id)?));
+                if input.starts_with("#") {
+                    return Ok(EvaluateResponse::from(
+                        auxtools.eval(
+                            params.frameId.map(|x| x as u32),
+                            &input[1..]
+                        )?
+                    ));
                 }
             }
         }


### PR DESCRIPTION
This requires an update to https://github.com/willox/auxtools/releases/tag/debug-v1.0.0. 

Basically, this'll let me add new debug console commands without having to touch SpacemanDMM. I'm gonna be adding some as I push my way through some DM bytecode related stuff so this'll save me a bunch of effort.

There's no new functionality here, it's still only `#help` and `#dis`.

The DLL is starting to get a bit big (it's still much smaller than a tiny example implementing maptick which for some reason comes out at 2.5MB) so I'll try to get them smaller before making any new releases.