### PR TITLE
pipe_output no longer stops piping after encountering invalid utf-8

### DIFF
--- a/src/langserver/debugger/launched.rs
+++ b/src/langserver/debugger/launched.rs
@@ -164,15 +164,15 @@ fn pipe_output<R: std::io::Read + Send + 'static>(seq: Arc<SequenceNumber>, keyw
         .spawn(move || {
             use std::io::BufRead;
 
-            let mut line = String::new();
+            let mut line = vec![];
             let mut buf_stream = std::io::BufReader::new(stream2);
             loop {
                 line.clear();
-                match buf_stream.read_line(&mut line) {
+                match buf_stream.read_until(b'\n', &mut line) {
                     Ok(0) => break,
                     Ok(_) => {
                         seq.issue_event(super::dap_types::OutputEvent {
-                            output: line.clone(),
+                            output: String::from_utf8_lossy(&line).into_owned(),
                             category: Some(keyword.to_owned()),
                             ..Default::default()
                         });


### PR DESCRIPTION
This only becomes a problem when stuff we haven't got control over decides to output to stdin or stderr.

https://github.com/vgstation-coders/vgstation13/pull/28789 shows (in the most recent responses) that they're using an internet explorer plugin which outputs some debug info to stderr and terminates it with some invalid utf-8 or something. I don't think the details on that side are too important, we just need to fix the next part: This makes the language server's `pipe_output` close the stream which _then_ makes auxtools panic when it tries writing to said stream (because `eprintln!()` will panic in such a case.)

Auxtools could handle this better, but there's no reason for the debugger to just stop piping output because it sees some wacky bytes.

