### PR TITLE
MiniExpr no longer supports list indexing

### DIFF
--- a/src/dreamchecker/tests/new_tests.rs
+++ b/src/dreamchecker/tests/new_tests.rs
@@ -4,7 +4,7 @@ extern crate dreamchecker as dc;
 use dc::test_helpers::*;
 
 pub const NEW_DOT_ERRORS: &[(u32, u16, &str)] = &[
-    (13, 14, "got '(', expected one of: operator, field access, ';'"),
+    (12, 14, "got '(', expected one of: operator, field access, ';'"),
 ];
 
 #[test]
@@ -20,11 +20,25 @@ fn new_dot() {
     new /obj()
     new /obj{name = "foo"}()
     new .subtype()
-    new L[1]()
     new src.name
     new foo()()
     new /obj[0]() // TODO: see parser.rs
     new 2 + 2() // TODO: see parser.rs
 "##.trim();
     check_errors_match(code, NEW_DOT_ERRORS);
+}
+
+pub const NEW_PRECEDENCE_ERRORS: &[(u32, u16, &str)] = &[
+    (4, 13, "got '(', expected one of: operator, field access, ';'"),
+];
+
+#[test]
+fn new_precedence() {
+    let code = r##"
+/mob/subtype
+/mob/proc/foo()
+/mob/proc/test()
+    new L[1]()
+"##.trim();
+    check_errors_match(code, NEW_PRECEDENCE_ERRORS);
 }

--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -329,7 +329,7 @@ pub enum NewType {
     /// A "mini-expression" in which to find the prefab to instantiate.
     MiniExpr {
         ident: Ident,
-        fields: Vec<IndexOrField>,
+        fields: Vec<Field>,
     },
 }
 
@@ -680,21 +680,16 @@ pub enum Follow {
     Call(IndexKind, Ident, Vec<Expression>),
 }
 
-/// Like a `Follow` but supports index or fields only.
+/// Like a `Follow` but only supports field accesses.
 #[derive(Debug, Clone, PartialEq)]
-pub enum IndexOrField {
-    /// Index the value by an expression.
-    Index(Box<Expression>),
-    /// Access a field of the value.
-    Field(IndexKind, Ident),
+pub struct Field {
+    pub kind: IndexKind,
+    pub ident: Ident,
 }
 
-impl From<IndexOrField> for Follow {
-    fn from(input: IndexOrField) -> Follow {
-        match input {
-            IndexOrField::Index(expr) => Follow::Index(expr),
-            IndexOrField::Field(kind, name) => Follow::Field(kind, name),
-        }
+impl From<Field> for Follow {
+    fn from(field: Field) -> Follow {
+        Follow::Field(field.kind, field.ident)
     }
 }
 


### PR DESCRIPTION
I noticed that this was different from BYOND's behaviour where `new x[y]` actually compiles as `(new x)[y]`. The same behaviour applies for `new x?[y]` so I don't anticipate the code I am removing being needed for that.

I confirmed that BYOND has been compiling it this way since at least 513.1490, so if it changed it was long ago.