### PR TITLE
auxtools debug server: expression evaluation

### DIFF
--- a/src/langserver/debugger/auxtools.rs
+++ b/src/langserver/debugger/auxtools.rs
@@ -217,9 +217,10 @@ impl Auxtools {
         }
     }
 
-    pub fn set_breakpoint(&mut self, instruction: &InstructionRef) -> Result<BreakpointSetResult, Box<dyn std::error::Error>> {
+    pub fn set_breakpoint(&mut self, instruction: InstructionRef, condition: Option<String>) -> Result<BreakpointSetResult, Box<dyn std::error::Error>> {
         self.send_or_disconnect(Request::BreakpointSet {
-            instruction: instruction.clone(),
+            instruction,
+            condition
         })?;
 
         match self.read_response_or_disconnect()? {

--- a/src/langserver/debugger/auxtools.rs
+++ b/src/langserver/debugger/auxtools.rs
@@ -165,10 +165,11 @@ impl Auxtools {
         }
     }
 
-    pub fn eval(&mut self, frame_id: Option<u32>, command: &str) -> Result<String, Box<dyn std::error::Error>> {
+    pub fn eval(&mut self, frame_id: Option<u32>, command: &str, context: Option<String>) -> Result<EvalResponse, Box<dyn std::error::Error>> {
         self.send_or_disconnect(Request::Eval{
             frame_id,
-            command: command.to_owned()
+            command: command.to_owned(),
+            context,
         })?;
 
         match self.read_response_or_disconnect()? {

--- a/src/langserver/debugger/auxtools_types.rs
+++ b/src/langserver/debugger/auxtools_types.rs
@@ -14,6 +14,7 @@ pub enum Request {
     Eval {
         frame_id: Option<u32>,
         command: String,
+        context: Option<String>,
     },
     CurrentInstruction {
         frame_id: u32,
@@ -58,7 +59,7 @@ pub enum Request {
 pub enum Response {
     Ack,
     StdDef(Option<String>),
-    Eval(String),
+    Eval(EvalResponse),
     CurrentInstruction(Option<InstructionRef>),
     BreakpointSet {
         result: BreakpointSetResult,
@@ -152,6 +153,12 @@ pub struct VariablesRef(pub i32);
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Variable {
     pub name: String,
+    pub value: String,
+    pub variables: Option<VariablesRef>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EvalResponse {
     pub value: String,
     pub variables: Option<VariablesRef>,
 }

--- a/src/langserver/debugger/auxtools_types.rs
+++ b/src/langserver/debugger/auxtools_types.rs
@@ -21,6 +21,7 @@ pub enum Request {
     },
     BreakpointSet {
         instruction: InstructionRef,
+        condition: Option<String>,
     },
     BreakpointUnset {
         instruction: InstructionRef,

--- a/src/langserver/debugger/evaluate.rs
+++ b/src/langserver/debugger/evaluate.rs
@@ -38,12 +38,17 @@ impl Debugger {
             }
 
             DebugClient::Auxtools(auxtools) => {
-                return Ok(EvaluateResponse::from(
-                    auxtools.eval(
-                        params.frameId.map(|x| x as u32),
-                        input
-                    )?
-                ));
+                let response = auxtools.eval(
+                    params.frameId.map(|x| x as u32),
+                    input,
+                    params.context,
+                )?;
+
+                return Ok(EvaluateResponse {
+                    result: response.value,
+                    variablesReference: response.variables.map(|x| x.0 as i64).unwrap_or(0),
+                    ..Default::default()
+                });
             }
         }
 

--- a/src/langserver/debugger/mod.rs
+++ b/src/langserver/debugger/mod.rs
@@ -395,6 +395,7 @@ handle_request! {
             supportsExceptionInfoRequest: Some(true),
             supportsConfigurationDoneRequest: Some(true),
             supportsFunctionBreakpoints: Some(true),
+            supportsConditionalBreakpoints: Some(matches!(self.client, DebugClient::Auxtools {..})),
             supportsDisassembleRequest: Some(true),
             exceptionBreakpointFilters: Some(vec![
                 ExceptionBreakpointsFilter {
@@ -661,13 +662,13 @@ handle_request! {
                             saved.insert((proc.clone(), override_id, offset as i64));
                             keep.insert((proc.clone(), override_id, offset as i64));
 
-                            let result = auxtools.set_breakpoint(&auxtools_types::InstructionRef {
+                            let result = auxtools.set_breakpoint(auxtools_types::InstructionRef {
                                 proc: auxtools_types::ProcRef {
                                     path: proc,
                                     override_id: override_id as u32
                                 },
                                 offset
-                            })?;
+                            }, sbp.condition)?;
 
                             breakpoints.push(match result {
                                 auxtools_types::BreakpointSetResult::Success { line } => {
@@ -811,13 +812,13 @@ handle_request! {
                     saved.insert(tup.clone());
                     keep.insert(tup.clone());
 
-                    let result = auxtools.set_breakpoint(&auxtools_types::InstructionRef {
+                    let result = auxtools.set_breakpoint(auxtools_types::InstructionRef {
                         proc: auxtools_types::ProcRef {
                             path: tup.0,
                             override_id: override_id as u32
                         },
                         offset: offset as u32,
-                    })?;
+                    }, sbp.condition)?;
 
                     breakpoints.push(match result {
                         auxtools_types::BreakpointSetResult::Success { line } => {

--- a/src/langserver/debugger/mod.rs
+++ b/src/langserver/debugger/mod.rs
@@ -395,7 +395,7 @@ handle_request! {
             supportsExceptionInfoRequest: Some(true),
             supportsConfigurationDoneRequest: Some(true),
             supportsFunctionBreakpoints: Some(true),
-            supportsConditionalBreakpoints: Some(matches!(self.client, DebugClient::Auxtools {..})),
+            supportsConditionalBreakpoints: Some(true),
             supportsDisassembleRequest: Some(true),
             exceptionBreakpointFilters: Some(vec![
                 ExceptionBreakpointsFilter {


### PR DESCRIPTION
The changes for the language server are minimal. This will require shipping version 2.0.0 of the debug server: ~https://github.com/willox/auxtools/releases/tag/debug-v2.0.0~ (use ~https://github.com/willox/auxtools/releases/tag/v2.1.0~ (use https://github.com/willox/auxtools/releases/tag/v2.2.0))

There are plenty of compiler features missing on the debug server's end, but it is definitely more than usable so I want to get it published. I plan on going a lot further this all of this, maybe we'll even have hot loading one day.

Noticeable differences from actual BYOND are:
1) It only compiles expressions! This means no for loops, no if statements, etc.
2) It lacks all static typing - the compiler has no access to type definitions and will treat all `.` accesses as `:` accesses and ignore the rules of const.
3) There are no implicit uses of `src`. This comes from the fact that there is no static typing, so to access a field on `src` you have to explicitly use `src.xyz` syntax.
4) Strings are lame. There is no interpolation support and the escape sequences are super limited too.
5) Some built-in procs aren't supported, but most are. They'll gracefully error if you try to use them.
6) No pre-processor.

For other limitations, just view the error list: https://github.com/willox/dmasm/blob/9ba328ef8c4e45c64072198e72c412cd9f685609/src/compiler.rs#L45-L76

tl;dr: relatively well-working debug console eval, watch eval, and conditional breakpoints