### PR TITLE
Lints for ambiguous `!` on the left hand side of a bitwise operation

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -40,6 +40,7 @@ Raised by DreamChecker:
 * `must_not_sleep` - `SpacemanDMM_should_not_sleep` directive
 * `redefined_proc` - `SpacemanDMM_can_be_redefined` directive
 * `ambiguous_in_lhs` - Raised on ambiguous operations on the left hand side of an `in` operation
+* `ambiguous_not_bitwise` - Raised on an ambiguous `!` on the left hand side of a bitwise operation
 * `no_typehint_implicit_new` - Raised on the use of `new` where no typehint is avaliable
 * `field_access_static_type` - Raised on using `.field_name` on a variable with no typehint
 * `proc_call_static_type` - Raised on using `.proc_name()` on a variable with no typehint

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -2060,9 +2060,10 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
     // checks for bitmath on a negated LHS
     fn check_negated_bitmath(&mut self, lhs: &dm::ast::Expression, location: Location, operator: BinaryOp) {
         if matches!(lhs, Expression::Base { unary, .. } if unary.contains(&UnaryOp::Not)) {
-            error(location, format!("Ambiguous unary operator on left side of bitwise `{}` operator", operator))
-            .with_errortype("ambig_not_bitwise_lhs")
+            error(location, format!("Ambiguous `!` on left side of bitwise `{}` operator", operator))
+            .with_errortype("ambiguous_not_bitwise")
             .set_severity(Severity::Warning)
+            .with_note(location, format!("Did you mean to put !(x {} y)?", operator))
             .with_note(location, format!("Did you mean to use the logical equivalent of `{}`?", operator))
             .with_note(location, "Did you mean to use `~` instead of `!`?")
             .register(self.context);

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -1645,7 +1645,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 match op {
                     BinaryOp::BitAnd |
                     BinaryOp::BitOr |
-                    BinaryOp::BitXor => self.check_negated_bitmath(lhs, location, *op),
+                    BinaryOp::BitXor => self.check_negated_bitwise(lhs, location, *op),
                     _ => {}
                 }
                 self.visit_binary(lty, rty, *op)
@@ -2057,8 +2057,8 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         }
     }
 
-    // checks for bitmath on a negated LHS
-    fn check_negated_bitmath(&mut self, lhs: &dm::ast::Expression, location: Location, operator: BinaryOp) {
+    // checks for bitwise operations on a negated LHS
+    fn check_negated_bitwise(&mut self, lhs: &dm::ast::Expression, location: Location, operator: BinaryOp) {
         if matches!(lhs, Expression::Base { unary, .. } if unary.contains(&UnaryOp::Not)) {
             error(location, format!("Ambiguous `!` on left side of bitwise `{}` operator", operator))
             .with_errortype("ambiguous_not_bitwise")

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -1645,7 +1645,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 match op {
                     BinaryOp::BitAnd |
                     BinaryOp::BitOr |
-                    BinaryOp::BitXor => self.check_negated_bitmath(lhs, rhs, location, *op),
+                    BinaryOp::BitXor => self.check_negated_bitmath(lhs, location, *op),
                     _ => {}
                 }
                 self.visit_binary(lty, rty, *op)
@@ -2058,12 +2058,13 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
     }
 
     // checks for bitmath on a negated LHS
-    fn check_negated_bitmath(&mut self, lhs: &Box<dm::ast::Expression>, rhs: &Box<dm::ast::Expression>, location: Location, operator: BinaryOp) {
-        if matches!(&**lhs, Expression::Base { unary, .. } if !unary.is_empty()) {
+    fn check_negated_bitmath(&mut self, lhs: &dm::ast::Expression, location: Location, operator: BinaryOp) {
+        if matches!(lhs, Expression::Base { unary, .. } if unary.contains(&UnaryOp::Not)) {
             error(location, format!("Ambiguous unary operator on left side of bitwise `{}` operator", operator))
-            .with_errortype("bitmath_negated_lhs")
+            .with_errortype("ambig_not_bitwise_lhs")
             .set_severity(Severity::Warning)
             .with_note(location, format!("Did you mean to use the logical equivalent of `{}`?", operator))
+            .with_note(location, "Did you mean to use `~` instead of `!`?")
             .register(self.context);
         }
     }

--- a/src/dreamchecker/tests/operator_tests.rs
+++ b/src/dreamchecker/tests/operator_tests.rs
@@ -58,7 +58,6 @@ pub const NEGATED_BITMATH_ERRORS: &[(u32, u16, &str)] = &[
     (2, 8, "Ambiguous unary operator on left side of bitwise `&` operator"),
     (4, 8, "Ambiguous unary operator on left side of bitwise `|` operator"),
     (6, 8, "Ambiguous unary operator on left side of bitwise `^` operator"),
-    (8, 8, "Ambiguous unary operator on left side of bitwise `&` operator"),
 ];
 
 #[test]
@@ -72,6 +71,8 @@ fn negated_bitmath() {
     if (!1 ^ 0)
         return
     if (~1 & 0)
+        return
+    if (1++ & 1)
         return
 "##.trim();
     check_errors_match(code, NEGATED_BITMATH_ERRORS);

--- a/src/dreamchecker/tests/operator_tests.rs
+++ b/src/dreamchecker/tests/operator_tests.rs
@@ -54,14 +54,14 @@ fn operator_overload() {
     check_errors_match(code, OP_OVERLOAD_ERRORS);
 }
 
-pub const NEGATED_BITMATH_ERRORS: &[(u32, u16, &str)] = &[
-    (2, 8, "Ambiguous unary operator on left side of bitwise `&` operator"),
-    (4, 8, "Ambiguous unary operator on left side of bitwise `|` operator"),
-    (6, 8, "Ambiguous unary operator on left side of bitwise `^` operator"),
+pub const NOT_AMBIG_BITWISE_ERRORS: &[(u32, u16, &str)] = &[
+    (2, 8, "Ambiguous `!` on left side of bitwise `&` operator"),
+    (4, 8, "Ambiguous `!` on left side of bitwise `|` operator"),
+    (6, 8, "Ambiguous `!` on left side of bitwise `^` operator"),
 ];
 
 #[test]
-fn negated_bitmath() {
+fn ambigous_not_bitwise() {
     let code = r##"
 /proc/test()
     if (!1 & 0)
@@ -75,5 +75,5 @@ fn negated_bitmath() {
     if (1++ & 1)
         return
 "##.trim();
-    check_errors_match(code, NEGATED_BITMATH_ERRORS);
+    check_errors_match(code, NOT_AMBIG_BITWISE_ERRORS);
 }

--- a/src/dreamchecker/tests/operator_tests.rs
+++ b/src/dreamchecker/tests/operator_tests.rs
@@ -1,4 +1,3 @@
-
 extern crate dreamchecker as dc;
 
 use dc::test_helpers::check_errors_match;
@@ -53,4 +52,30 @@ fn operator_overload() {
     T++
 "##.trim();
     check_errors_match(code, OP_OVERLOAD_ERRORS);
+}
+
+pub const NOTAND_ERRORS: &[(u32, u16, &str)] = &[
+    (2, 8, "Attempting to `&` a false left side"),
+    (6, 8, "Attempting to `|` a false left side"),
+    (10, 8, "Attempting to `^` a false left side"),
+];
+
+#[test]
+fn notand() {
+    let code = r##"
+/proc/test()
+    if (!1 & 0)
+        return
+    if (!0 & 0)
+        return
+    if (!1 | 0)
+        return
+    if (!0 | 0)
+        return
+    if (!1 ^ 0)
+        return
+    if (!0 ^ 0)
+        return
+"##.trim();
+    check_errors_match(code, NOTAND_ERRORS);
 }

--- a/src/dreamchecker/tests/operator_tests.rs
+++ b/src/dreamchecker/tests/operator_tests.rs
@@ -54,28 +54,25 @@ fn operator_overload() {
     check_errors_match(code, OP_OVERLOAD_ERRORS);
 }
 
-pub const NOTAND_ERRORS: &[(u32, u16, &str)] = &[
-    (2, 8, "Attempting to `&` a false left side"),
-    (6, 8, "Attempting to `|` a false left side"),
-    (10, 8, "Attempting to `^` a false left side"),
+pub const NEGATED_BITMATH_ERRORS: &[(u32, u16, &str)] = &[
+    (2, 8, "Ambiguous unary operator on left side of bitwise `&` operator"),
+    (4, 8, "Ambiguous unary operator on left side of bitwise `|` operator"),
+    (6, 8, "Ambiguous unary operator on left side of bitwise `^` operator"),
+    (8, 8, "Ambiguous unary operator on left side of bitwise `&` operator"),
 ];
 
 #[test]
-fn notand() {
+fn negated_bitmath() {
     let code = r##"
 /proc/test()
     if (!1 & 0)
         return
-    if (!0 & 0)
-        return
     if (!1 | 0)
-        return
-    if (!0 | 0)
         return
     if (!1 ^ 0)
         return
-    if (!0 ^ 0)
+    if (~1 & 0)
         return
 "##.trim();
-    check_errors_match(code, NOTAND_ERRORS);
+    check_errors_match(code, NEGATED_BITMATH_ERRORS);
 }


### PR DESCRIPTION
title, essentially
Puts some helpful hints in order of likelihood. Could be intended to be: `!(x & y)` or `!x && y` or `~x & y`

Fulfils https://github.com/SpaceManiac/SpacemanDMM/projects/1#card-37357276