### PR TITLE
Basic handling of relative type-paths to procs

### DIFF
--- a/src/langserver/completion.rs
+++ b/src/langserver/completion.rs
@@ -6,7 +6,7 @@ use lsp_types::*;
 
 use dm::ast::PathOp;
 use dm::annotation::Annotation;
-use dm::objtree::{TypeRef, TypeVar, TypeProc, ProcValue};
+use dm::objtree::{TypeRef, NavigatePathResult, TypeVar, TypeProc, ProcValue};
 
 use crate::{Engine, Span, is_constructor_name};
 use crate::symbol_search::contains;
@@ -206,7 +206,7 @@ impl<'a> Engine<'a> {
                 decl = Some("verb");
                 break;
             }
-            if let Some(next) = ty.navigate(op, name) {
+            if let Some(next) = ty.navigate(op, name).map(NavigatePathResult::ty) {
                 ty = next;
             } else {
                 break;


### PR DESCRIPTION
Fixes false errors arising from relative paths to procs such as: _error: failed to resolve path .HasProximity_ even when HasProximity is defined on the current type.


Details:
- Adds a function that will attempt to resolve an identifer as a proc name if initial resolution fails; Returns NavigatePathResult so callers will know if it resolved to a proc or otherwise.
- Use that function when resolving '.', '/', or ':' path operators in navigate(), as those operators can resolve to a proc reference and modify navigate_path to handle the case when navigate() resolves to a proc refernce.
- Add unit tests covering common cases.
  - I drew test cases from the examples documented in SS13's _callback.dm_.

Example failure case:
```dm
/obj/machinery/camera/HasProximity(turf/T, atom/movable/AM, old_loc)
	// etc
/obj/machinery/camera/proc/upgradeMotion()
	sense_proximity(callback = .HasProximity)
```