### PR TITLE
Bumped up minor version to 1556

### DIFF
--- a/src/dreammaker/builtins.rs
+++ b/src/dreammaker/builtins.rs
@@ -9,7 +9,7 @@ use super::constants::Constant;
 use super::docs::{BuiltinDocs, DocCollection};
 
 const DM_VERSION: i32 = 514;
-const DM_BUILD: i32 = 1554;
+const DM_BUILD: i32 = 1556;
 
 /// Register BYOND builtin macros to the given define map.
 pub fn default_defines(defines: &mut DefineMap) {


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/59771
minimum compile version is being changed to 1556 as a bunch of sendmap profiling seems to be utilised only on the version 1556 on tgstation, so these ifdef checks have been removed and the minimum compiler version has been brought up to 514.1556