### PR TITLE
Fix particles not actually being assumed to be particles

### DIFF
--- a/src/dreamchecker/tests/static_type_tests.rs
+++ b/src/dreamchecker/tests/static_type_tests.rs
@@ -15,6 +15,8 @@ fn field_access() {
     var/list/L = list()
     L[1].name
     L?[1].name
+    var/atom/movable/particle_holder = new
+    particle_holder.particles.height
 "##.trim();
     check_errors_match(code, FIELD_ACCESS_ERRORS);
 }

--- a/src/dreammaker/builtins.rs
+++ b/src/dreammaker/builtins.rs
@@ -692,7 +692,7 @@ pub fn register_builtins(tree: &mut ObjectTree) {
         atom/movable/var/tmp/list/locs;  // not editable
         atom/movable/var/screen_loc;
         atom/movable/var/glide_size = int!(0);
-        atom/movable/var/particles;
+        atom/movable/var/particles/particles;
         atom/movable/var/step_size = int!(32);
         atom/movable/var/step_x = int!(0);
         atom/movable/var/step_y = int!(0);


### PR DESCRIPTION
I was getting incorrect errors as seen below
![image](https://user-images.githubusercontent.com/57223640/125641948-3ac9fb4f-1be7-4dd2-aa0a-802a90fc16de.png)
