### PR TITLE
Better fonts

### DIFF
--- a/src/dmdoc/template/dmdoc.css
+++ b/src/dmdoc/template/dmdoc.css
@@ -6,6 +6,7 @@ body {
     line-height: 1.3;
     max-width: 73%;
     overflow-y: scroll;
+    font-family: Arial;
 }
 pre, code {
     background: white;
@@ -15,6 +16,9 @@ pre, code {
 pre {
     padding: 8px;
     white-space: pre-wrap;
+}
+code {
+    font-family: Consolas;
 }
 a {
     color: #333333;


### PR DESCRIPTION
Uses a less "sharp" font. All the contents will be using Arial while codeblocks will use Consolas
![image](https://user-images.githubusercontent.com/24603524/126926239-40b8dcf1-c0c4-4ebf-97e9-c6a23c927faf.png)
