### PR TITLE
Fix directive misspelling

### DIFF
--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -1056,7 +1056,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             path.remove(0);
             DMError::new(leading_loc, "'var/' is unnecessary here")
                 .set_severity(Severity::Hint)
-                .with_errortype("var_in_proc_paramater")
+                .with_errortype("var_in_proc_parameter")
                 .register(self.context);
         }
         let mut var_type: VarType = path.into_iter().collect();


### PR DESCRIPTION
Huh, entry `var_in_proc_parameter = "error"` in config don't work because of this.