### PR TITLE
use indexmap instead of linked hashmap, switch hasher to use ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
 ]
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byte-tools"
@@ -160,9 +160,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 dependencies = [
  "jobserver",
 ]
@@ -188,12 +188,24 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+checksum = "64c01c1c607d25c71bbaa67c113d6c6b36c434744b4fd66691d711b5b1bc0c8b"
 dependencies = [
  "chrono",
+ "chrono-tz-build",
+ "phf 0.10.0",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+dependencies = [
  "parse-zoneinfo",
+ "phf 0.10.0",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -215,6 +227,7 @@ dependencies = [
 name = "cli"
 version = "1.3.1"
 dependencies = [
+ "ahash",
  "chrono",
  "dmm-tools",
  "dreammaker",
@@ -315,6 +328,7 @@ dependencies = [
 name = "dm-langserver"
 version = "1.5.0"
 dependencies = [
+ "ahash",
  "bincode",
  "chrono",
  "dreamchecker",
@@ -378,6 +392,7 @@ dependencies = [
 name = "dreamchecker"
 version = "1.7.1"
 dependencies = [
+ "ahash",
  "chrono",
  "dreammaker",
  "git2",
@@ -398,7 +413,7 @@ dependencies = [
  "interval-tree",
  "lodepng",
  "ordered-float",
- "phf",
+ "phf 0.8.0",
  "serde",
  "serde_derive",
  "termcolor",
@@ -429,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -514,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.20"
+version = "0.13.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+checksum = "2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700"
 dependencies = [
  "bitflags",
  "libc",
@@ -645,15 +660,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jobserver"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ca711fd837261e14ec9e674f092cbb931d3fa1482b017ae59328ddc6f3212b"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
@@ -679,15 +694,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.21+1.1.0"
+version = "0.12.24+1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+checksum = "ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c"
 dependencies = [
  "cc",
  "libc",
@@ -750,9 +765,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matrixmultiply"
@@ -765,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -863,9 +878,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "ordered-float"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
+checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
 dependencies = [
  "num-traits",
 ]
@@ -935,8 +950,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.8.0",
  "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -945,8 +979,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.8.0",
  "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -955,8 +999,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -973,10 +1017,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.19"
+name = "phf_shared"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "png"
@@ -992,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-error"
@@ -1028,9 +1082,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -1049,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -1227,18 +1281,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1247,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1281,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "slug"
@@ -1302,9 +1356,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1313,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1326,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1337,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95b0d8a46da5fe3ea119394a6c7f1e745f9de359081641c99946e2bf55d4f2"
+checksum = "ed0c0eee8fbbbaab449287574b292f21ca53224b92a07b4a23266b77376f0ce7"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1396,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1420,15 +1474,24 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "uncased"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -1491,12 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -1515,9 +1575,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell",
@@ -351,12 +351,13 @@ dependencies = [
 name = "dmm-tools"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bumpalo",
  "bytemuck",
  "dreammaker",
  "gfx_core",
+ "indexmap",
  "inflate",
- "linked-hash-map",
  "lodepng",
  "ndarray",
  "png",
@@ -388,12 +389,13 @@ dependencies = [
 name = "dreammaker"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bitflags",
  "builtins-proc-macro",
  "color_space",
  "guard",
+ "indexmap",
  "interval-tree",
- "linked-hash-map",
  "lodepng",
  "ordered-float",
  "phf",
@@ -616,6 +618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "inflate"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,11 +706,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.2"
-source = "git+https://github.com/SpaceManiac/linked-hash-map?branch=get-key-value#7e6de06f9817fbb17a257af3777b0852f46cb894"
 
 [[package]]
 name = "lodepng"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0.9"
 rayon = "1.0.0"
 dreammaker = { path = "../dreammaker" }
 dmm-tools = { path = "../tools", features = ["png"] }
+ahash = "0.7.6"
 
 [build-dependencies]
 chrono = "0.4.0"

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -26,6 +26,8 @@ use structopt::StructOpt;
 use dm::objtree::ObjectTree;
 use dmm_tools::*;
 
+use ahash::RandomState;
+
 // ----------------------------------------------------------------------------
 // Main driver
 
@@ -244,7 +246,7 @@ fn run(opt: &Opt, command: &Command, context: &mut Context) {
 
             let render_passes = &dmm_tools::render_passes::configure(&context.dm_context.config().map_renderer, enable, disable);
             let paths: Vec<&Path> = files.iter().map(|p| p.as_ref()).collect();
-            let errors: RwLock<HashSet<String>> = Default::default();
+            let errors: RwLock<HashSet<String, RandomState>> = Default::default();
 
             let perform_job = move |path: &Path| {
                 let mut filename;
@@ -393,7 +395,7 @@ fn run(opt: &Opt, command: &Command, context: &mut Context) {
                 num_keys: usize,
             }
 
-            let mut report = HashMap::new();
+            let mut report = HashMap::with_hasher(RandomState::default());
             for path in files.iter() {
                 let path = std::path::Path::new(path);
                 let map = dmm::Map::from_file(path).unwrap();
@@ -565,7 +567,7 @@ fn render_many(context: &Context, command: RenderManyCommand) -> RenderManyComma
         ..
     } = *context;
     let render_passes = &dmm_tools::render_passes::configure_list(&context.dm_context.config().map_renderer, &command.enable, &command.disable);
-    let errors: RwLock<HashSet<String>> = Default::default();
+    let errors: RwLock<HashSet<String, RandomState>> = Default::default();
 
     // Prepare output directory.
     let output_directory = command.output_directory;

--- a/src/dreamchecker/Cargo.toml
+++ b/src/dreamchecker/Cargo.toml
@@ -16,6 +16,7 @@ path = "main.rs"
 dreammaker = { path = "../dreammaker" }
 guard = "0.5.0"
 serde_json = "1.0"
+ahash = "0.7.6"
 
 [build-dependencies]
 chrono = "0.4.0"

--- a/src/dreamchecker/lib.rs
+++ b/src/dreamchecker/lib.rs
@@ -11,6 +11,8 @@ use dm::ast::*;
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
+use ahash::RandomState;
+
 mod type_expr;
 use type_expr::TypeExpr;
 
@@ -1142,7 +1144,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
     }
 
     pub fn run(&mut self, block: &'o [Spanned<Statement>]) {
-        let mut local_vars = HashMap::<String, LocalVar>::new();
+        let mut local_vars = HashMap::<String, LocalVar, RandomState>::with_hasher(RandomState::default());
         local_vars.insert(".".to_owned(), Analysis::empty().into());
         local_vars.insert("args".to_owned(), Analysis::from_static_type_impure(self.objtree.expect("/list")).into());
         local_vars.insert("usr".to_owned(), Analysis::from_static_type(self.objtree.expect("/mob")).into());
@@ -1207,7 +1209,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         }
     }
 
-    fn visit_block(&mut self, block: &'o [Spanned<Statement>], local_vars: &mut HashMap<String, LocalVar<'o>>) -> ControlFlow {
+    fn visit_block(&mut self, block: &'o [Spanned<Statement>], local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) -> ControlFlow {
         let mut term = ControlFlow::allfalse();
         for stmt in block.iter() {
             if term.terminates() {
@@ -1253,7 +1255,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         }
     }
 
-    fn visit_statement(&mut self, location: Location, statement: &'o Statement, local_vars: &mut HashMap<String, LocalVar<'o>>) -> ControlFlow {
+    fn visit_statement(&mut self, location: Location, statement: &'o Statement, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) -> ControlFlow {
         match statement {
             Statement::Expr(expr) => {
                 match expr {
@@ -1542,11 +1544,11 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         return ControlFlow::allfalse()
     }
 
-    fn visit_var_stmt(&mut self, location: Location, var: &'o VarStatement, local_vars: &mut HashMap<String, LocalVar<'o>>) {
+    fn visit_var_stmt(&mut self, location: Location, var: &'o VarStatement, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) {
         self.visit_var(location, &var.var_type, &var.name, var.value.as_ref(), local_vars)
     }
 
-    fn visit_var(&mut self, location: Location, var_type: &VarType, name: &str, value: Option<&'o Expression>, local_vars: &mut HashMap<String, LocalVar<'o>>) {
+    fn visit_var(&mut self, location: Location, var_type: &VarType, name: &str, value: Option<&'o Expression>, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) {
         // Calculate type hint
         let static_type = self.env.static_type(location, &var_type.type_path);
         // Visit the expression if it's there
@@ -1560,7 +1562,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         local_vars.insert(name.to_owned(), LocalVar { location, analysis });
     }
 
-    fn visit_expression(&mut self, location: Location, expression: &'o Expression, type_hint: Option<TypeRef<'o>>, local_vars: &mut HashMap<String, LocalVar<'o>>) -> Analysis<'o> {
+    fn visit_expression(&mut self, location: Location, expression: &'o Expression, type_hint: Option<TypeRef<'o>>, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) -> Analysis<'o> {
         match expression {
             Expression::Base { unary, term, follow } => {
                 let base_type_hint = if follow.is_empty() && unary.is_empty() {
@@ -1669,7 +1671,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         }
     }
 
-    fn visit_term(&mut self, location: Location, term: &'o Term, type_hint: Option<TypeRef<'o>>, local_vars: &mut HashMap<String, LocalVar<'o>>) -> Analysis<'o> {
+    fn visit_term(&mut self, location: Location, term: &'o Term, type_hint: Option<TypeRef<'o>>, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) -> Analysis<'o> {
         match term {
             Term::Null => Analysis::null(),
             Term::Int(number) => Analysis::from_value(self.objtree, Constant::from(*number), type_hint),
@@ -1904,7 +1906,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         }
     }
 
-    fn visit_follow(&mut self, location: Location, lhs: Analysis<'o>, rhs: &'o Follow, local_vars: &mut HashMap<String, LocalVar<'o>>) -> Analysis<'o> {
+    fn visit_follow(&mut self, location: Location, lhs: Analysis<'o>, rhs: &'o Follow, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) -> Analysis<'o> {
         match rhs {
             Follow::Field(PropertyAccessKind::Colon, _) => Analysis::empty(),
             Follow::Field(PropertyAccessKind::SafeColon, _) => Analysis::empty(),
@@ -2014,7 +2016,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
     }
 
     // checks operatorX overloads on types
-    fn check_operator_overload(&mut self, rhs: Analysis<'o>, location: Location, operator: &str, local_vars: &mut HashMap<String, LocalVar<'o>>) -> Analysis<'o> {
+    fn check_operator_overload(&mut self, rhs: Analysis<'o>, location: Location, operator: &str, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) -> Analysis<'o> {
         if let Some(impurity) = rhs.is_impure {
             if impurity {
                 self.env.impure_procs.insert_violator(self.proc_ref, &format!("{} done on non-local var", operator), location);
@@ -2041,7 +2043,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         return Analysis::empty()
     }
 
-    fn visit_unary(&mut self, rhs: Analysis<'o>, op: &UnaryOp, location: Location, local_vars: &mut HashMap<String, LocalVar<'o>>) -> Analysis<'o> {
+    fn visit_unary(&mut self, rhs: Analysis<'o>, op: &UnaryOp, location: Location, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) -> Analysis<'o> {
         match op {
             // !x just evaluates the "truthiness" of x and negates it, returning 1 or 0
             UnaryOp::Not => Analysis::from(assumption_set![Assumption::IsNum(true)]),
@@ -2131,7 +2133,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         }
     }
 
-    fn visit_call(&mut self, location: Location, src: TypeRef<'o>, proc: ProcRef<'o>, args: &'o [Expression], is_exact: bool, local_vars: &mut HashMap<String, LocalVar<'o>>) -> Analysis<'o> {
+    fn visit_call(&mut self, location: Location, src: TypeRef<'o>, proc: ProcRef<'o>, args: &'o [Expression], is_exact: bool, local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) -> Analysis<'o> {
         self.env.call_tree.entry(self.proc_ref).or_default().push((proc, location, self.inside_newcontext != 0));
         if let Some((privateproc, true, decllocation)) = self.env.private.get_self_or_parent(proc) {
             if self.ty != privateproc.ty() {
@@ -2145,9 +2147,9 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         // identify and register kwargs used
         let mut any_kwargs_yet = false;
 
-        let mut param_name_map = HashMap::new();
-        let mut param_expr_map = HashMap::new();
-        let mut param_idx_map = HashMap::new();
+        let mut param_name_map = HashMap::with_hasher(RandomState::default());
+        let mut param_expr_map = HashMap::with_hasher(RandomState::default());
+        let mut param_idx_map = HashMap::with_hasher(RandomState::default());
         let mut param_idx = 0;
         let mut arglist_used = false;
 
@@ -2286,7 +2288,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         }
     }
 
-    fn visit_arguments(&mut self, location: Location, args: &'o [Expression], local_vars: &mut HashMap<String, LocalVar<'o>>) {
+    fn visit_arguments(&mut self, location: Location, args: &'o [Expression], local_vars: &mut HashMap<String, LocalVar<'o>, RandomState>) {
         for arg in args {
             let mut argument_value = arg;
             if let Expression::AssignOp { op: AssignOp::Assign, lhs, rhs } = arg {

--- a/src/dreamchecker/type_expr.rs
+++ b/src/dreamchecker/type_expr.rs
@@ -8,12 +8,14 @@ use dm::constants::Constant;
 use dm::objtree::{ObjectTree, ProcRef};
 use dm::{DMError, Location};
 
+use ahash::RandomState;
+
 use crate::{Analysis, StaticType};
 
 pub struct TypeExprContext<'o, 't> {
     pub objtree: &'o ObjectTree,
-    pub param_name_map: HashMap<&'t str, Analysis<'o>>,
-    pub param_idx_map: HashMap<usize, Analysis<'o>>,
+    pub param_name_map: HashMap<&'t str, Analysis<'o>, RandomState>,
+    pub param_idx_map: HashMap<usize, Analysis<'o>, RandomState>,
 }
 
 impl<'o, 't> TypeExprContext<'o, 't> {

--- a/src/dreammaker/Cargo.toml
+++ b/src/dreammaker/Cargo.toml
@@ -20,10 +20,8 @@ toml = "0.5.5"
 guard = "0.5.0"
 phf = { version = "0.8.0", features = ["macros"] }
 color_space = "0.5.3"
-
-[dependencies.linked-hash-map]
-git = "https://github.com/SpaceManiac/linked-hash-map"
-branch = "get-key-value"
+ahash = "0.7.6"
+indexmap = "1.7.0"
 
 [dev-dependencies]
 walkdir = "2.0.1"

--- a/src/dreammaker/ast.rs
+++ b/src/dreammaker/ast.rs
@@ -5,7 +5,8 @@ use std::fmt;
 use std::iter::FromIterator;
 use phf::phf_map;
 
-use linked_hash_map::LinkedHashMap;
+use indexmap::IndexMap;
+use ahash::RandomState;
 
 use crate::error::Location;
 
@@ -286,7 +287,7 @@ augmented! {
 #[derive(Clone, PartialEq, Debug)]
 pub struct Prefab {
     pub path: TypePath,
-    pub vars: LinkedHashMap<Ident, Expression>,
+    pub vars: IndexMap<Ident, Expression, RandomState>,
 }
 
 impl From<TypePath> for Prefab {
@@ -299,7 +300,7 @@ impl From<TypePath> for Prefab {
 }
 
 /// Formatting helper for variable arrays.
-pub struct FormatVars<'a, E>(pub &'a LinkedHashMap<Ident, E>);
+pub struct FormatVars<'a, E>(pub &'a IndexMap<Ident, E, RandomState>);
 
 impl<'a, E: fmt::Display> fmt::Display for FormatVars<'a, E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/dreammaker/config.rs
+++ b/src/dreammaker/config.rs
@@ -5,6 +5,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
 
+use ahash::RandomState;
 use serde::Deserialize;
 
 use crate::error::Severity;
@@ -18,7 +19,7 @@ pub struct Config {
 
     // diagnostic configuration
     display: WarningDisplay,
-    diagnostics: HashMap<String, WarningLevel>,
+    diagnostics: HashMap<String, WarningLevel, RandomState>,
     pub code_standards: CodeStandards,
 
     // tool-specific configuration
@@ -98,10 +99,10 @@ pub struct MapRenderer {
     /// Map from render pass name to whether it should be enabled/disabled.
     ///
     /// Priority is: CLI arguments > config > defaults.
-    pub render_passes: HashMap<String, bool>,
+    pub render_passes: HashMap<String, bool, RandomState>,
 
     /// Map from typepath to layer number.
-    pub fancy_layers: HashMap<String, f32>,
+    pub fancy_layers: HashMap<String, f32, RandomState>,
 
     /// List of typepath to just hide
     pub hide_invisible: Vec<String>,

--- a/src/dreammaker/constants.rs
+++ b/src/dreammaker/constants.rs
@@ -24,10 +24,10 @@ pub struct Pop {
 
 
 impl std::hash::Hash for Pop {
-	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-		self.path.hash(state);
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.path.hash(state);
         self.vars.keys().for_each(|key| {key.hash(state)});
-	}
+    }
 }
 
 impl From<TreePath> for Pop {

--- a/src/dreammaker/error.rs
+++ b/src/dreammaker/error.rs
@@ -5,6 +5,8 @@ use std::path::{PathBuf, Path};
 use std::cell::{RefCell, Ref, RefMut};
 use std::collections::HashMap;
 
+use ahash::RandomState;
+
 use termcolor::{ColorSpec, Color};
 
 use crate::config::Config;
@@ -30,7 +32,7 @@ pub struct FileList {
     /// The list of loaded files.
     files: RefCell<Vec<PathBuf>>,
     /// Reverse mapping from paths to file numbers.
-    reverse_files: RefCell<HashMap<PathBuf, FileId>>,
+    reverse_files: RefCell<HashMap<PathBuf, FileId, RandomState>>,
 }
 
 /// A diagnostics context, tracking loaded files and any observed errors.

--- a/src/dreammaker/lib.rs
+++ b/src/dreammaker/lib.rs
@@ -1,7 +1,7 @@
 //! Parsing suite for DreamMaker, the language of the BYOND game engine.
 #![forbid(unsafe_code)]
 
-extern crate linked_hash_map;
+extern crate indexmap;
 extern crate interval_tree;
 extern crate lodepng;
 #[macro_use] extern crate bitflags;

--- a/src/dreammaker/objtree.rs
+++ b/src/dreammaker/objtree.rs
@@ -3,7 +3,8 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use linked_hash_map::LinkedHashMap;
+use indexmap::IndexMap;
+use ahash::RandomState;
 
 use super::ast::{Expression, VarType, VarSuffix, PathOp, Parameter, Block, ProcDeclKind, Ident};
 use super::constants::{Constant, Pop};
@@ -44,7 +45,7 @@ impl SymbolIdSource {
 // ----------------------------------------------------------------------------
 // Variables
 
-pub type Vars = LinkedHashMap<String, Constant>;
+pub type Vars = IndexMap<String, Constant, RandomState>;
 
 #[derive(Debug, Clone)]
 pub struct VarDeclaration {
@@ -118,9 +119,9 @@ pub struct Type {
     pub location: Location,
     location_specificity: usize,
     /// Variables which this type has declarations or overrides for.
-    pub vars: LinkedHashMap<String, TypeVar>,
+    pub vars: IndexMap<String, TypeVar, RandomState>,
     /// Procs and verbs which this type has declarations or overrides for.
-    pub procs: LinkedHashMap<String, TypeProc>,
+    pub procs: IndexMap<String, TypeProc, RandomState>,
     parent_path: NodeIndex,
     parent_type: NodeIndex,
     pub docs: DocCollection,
@@ -898,10 +899,10 @@ impl ObjectTree {
     ) -> &mut TypeVar {
         // TODO: warn and merge docs for repeats
         match self[ty].vars.entry(name.to_owned()) {
-            linked_hash_map::Entry::Vacant(slot) => {
+            indexmap::map::Entry::Vacant(slot) => {
                 slot.insert(TypeVar { value, declaration })
             },
-            linked_hash_map::Entry::Occupied(slot) => {
+            indexmap::map::Entry::Occupied(slot) => {
                 let type_var = slot.into_mut();
                 if let Some(declaration) = declaration {
                     type_var.declaration = Some(declaration);

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -6,6 +6,8 @@ use std::ops::Range;
 
 use indexmap::IndexMap;
 
+use ahash::RandomState;
+
 use super::{DMError, Location, HasLocation, Context, Severity, FileId};
 use super::lexer::{LocatedToken, Token, Punctuation};
 use super::objtree::{ObjectTree, NodeIndex};
@@ -1701,7 +1703,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
         self.annotate(start, || Annotation::TypePath(parts.clone()));
 
         // parse vars if we find them
-        let mut vars = IndexMap::default();
+        let mut vars = IndexMap::with_hasher(RandomState::default());
         if let Some(()) = self.exact(Token::Punct(Punctuation::LBrace))? {
             self.separated(Punctuation::Semicolon, Punctuation::RBrace, Some(()), |this| {
                 let key = require!(this.ident());

--- a/src/dreammaker/parser.rs
+++ b/src/dreammaker/parser.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::ops::Range;
 
-use linked_hash_map::LinkedHashMap;
+use indexmap::IndexMap;
 
 use super::{DMError, Location, HasLocation, Context, Severity, FileId};
 use super::lexer::{LocatedToken, Token, Punctuation};
@@ -1701,7 +1701,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
         self.annotate(start, || Annotation::TypePath(parts.clone()));
 
         // parse vars if we find them
-        let mut vars = LinkedHashMap::default();
+        let mut vars = IndexMap::default();
         if let Some(()) = self.exact(Token::Punct(Punctuation::LBrace))? {
             self.separated(Punctuation::Semicolon, Punctuation::RBrace, Some(()), |this| {
                 let key = require!(this.ident());

--- a/src/dreammaker/preprocessor.rs
+++ b/src/dreammaker/preprocessor.rs
@@ -5,6 +5,8 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::borrow::Cow;
 
+use ahash::RandomState;
+
 use interval_tree::{IntervalTree, range};
 
 use super::{DMError, Location, HasLocation, FileId, Context, Severity};
@@ -166,7 +168,7 @@ impl std::ops::DerefMut for DefineHistory {
 /// stack is exhausted.
 #[derive(Debug, Clone, Default)]
 pub struct DefineMap {
-    inner: HashMap<String, Vec<(Location, Define)>>,
+    inner: HashMap<String, Vec<(Location, Define)>, RandomState>,
 }
 
 impl DefineMap {
@@ -378,7 +380,7 @@ pub struct Preprocessor<'ctx> {
     env_file: PathBuf,
 
     include_stack: IncludeStack<'ctx>,
-    include_locations: HashMap<FileId, Location>,
+    include_locations: HashMap<FileId, Location, RandomState>,
     last_input_loc: Location,
     output: VecDeque<Token>,
     ifdef_stack: Vec<Ifdef>,
@@ -392,7 +394,7 @@ pub struct Preprocessor<'ctx> {
     scripts: Vec<PathBuf>,
 
     last_printable_input_loc: Location,
-    danger_idents: HashMap<Ident, Location>,
+    danger_idents: HashMap<Ident, Location, RandomState>,
     in_interp_string: u32,
 
     docs_in: VecDeque<(Location, DocComment)>,

--- a/src/langserver/Cargo.toml
+++ b/src/langserver/Cargo.toml
@@ -23,6 +23,7 @@ libc = "0.2.65"
 guard = "0.5.0"
 regex = "1.3"
 lazy_static = "1.4"
+ahash = "0.7.6"
 
 [build-dependencies]
 chrono = "0.4.0"

--- a/src/langserver/completion.rs
+++ b/src/langserver/completion.rs
@@ -11,6 +11,8 @@ use dm::objtree::{TypeRef, TypeVar, TypeProc, ProcValue};
 use crate::{Engine, Span, is_constructor_name};
 use crate::symbol_search::contains;
 
+use ahash::RandomState;
+
 static PROC_KEYWORDS: &[&str] = &[
     // Implicit variables
     "args",
@@ -100,7 +102,7 @@ fn item_documentation(docs: &dm::docs::DocCollection) -> Option<Documentation> {
 
 fn items_ty<'a>(
     results: &mut Vec<CompletionItem>,
-    skip: &mut HashSet<(&str, &'a String)>,
+    skip: &mut HashSet<(&str, &'a String), RandomState>,
     ty: TypeRef<'a>,
     query: &str,
 ) {
@@ -253,7 +255,7 @@ impl<'a> Engine<'a> {
         }
 
         let mut next = Some(ty).filter(|ty| !ty.is_root());
-        let mut skip = HashSet::new();
+        let mut skip = HashSet::with_hasher(RandomState::default());
         while let Some(ty) = next {
             // override a parent's var
             for (name, var) in ty.get().vars.iter() {
@@ -347,7 +349,7 @@ impl<'a> Engine<'a> {
                 proc: None,
             }) => {
                 let mut next = Some(ty);
-                let mut skip = HashSet::new();
+                let mut skip = HashSet::with_hasher(RandomState::default());
                 while let Some(ty) = next {
                     // reference a declared proc
                     for (name, proc) in ty.get().procs.iter() {
@@ -443,7 +445,7 @@ impl<'a> Engine<'a> {
 
         // fields
         let mut next = Some(ty);
-        let mut skip = HashSet::new();
+        let mut skip = HashSet::with_hasher(RandomState::default());
         while let Some(ty) = next {
             items_ty(results, &mut skip, ty, query);
             next = ty.parent_type();
@@ -460,7 +462,7 @@ impl<'a> Engine<'a> {
         I: Iterator<Item = (Span, &'b Annotation)> + Clone,
     {
         let mut next = self.find_scoped_type(iter, priors);
-        let mut skip = HashSet::new();
+        let mut skip = HashSet::with_hasher(RandomState::default());
         while let Some(ty) = next {
             items_ty(results, &mut skip, ty, query);
             next = ty.parent_type_without_root();

--- a/src/langserver/debugger/dap_types.rs
+++ b/src/langserver/debugger/dap_types.rs
@@ -6,6 +6,8 @@
 use std::collections::HashMap;
 use serde_json::Value;
 
+use ahash::RandomState;
+
 pub trait Request {
     type Params;
     type Result;
@@ -1527,7 +1529,7 @@ pub struct Message {
     /**
      * An object used as a dictionary for looking up the variables in the format string.
      */
-    pub variables: Option<HashMap<String, String>>,
+    pub variables: Option<HashMap<String, String, RandomState>>,
 
     /**
      * If true send to telemetry.

--- a/src/langserver/debugger/extools.rs
+++ b/src/langserver/debugger/extools.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::error::Error;
 
+use ahash::RandomState;
+
 use super::SequenceNumber;
 use super::dap_types;
 use super::extools_types::*;
@@ -138,7 +140,7 @@ pub struct Extools {
     seq: Arc<SequenceNumber>,
     sender: ExtoolsSender,
     threads: Arc<Mutex<HashMap<i64, ThreadInfo>>>,
-    bytecode: HashMap<(String, usize), Vec<DisassembledInstruction>>,
+    bytecode: HashMap<(String, usize), Vec<DisassembledInstruction>, RandomState>,
     get_type_rx: mpsc::Receiver<GetTypeResponse>,
     bytecode_rx: mpsc::Receiver<DisassembledProc>,
     get_field_rx: mpsc::Receiver<GetAllFieldsResponse>,
@@ -170,7 +172,7 @@ impl Extools {
             seq,
             sender,
             threads: Arc::new(Mutex::new(HashMap::new())),
-            bytecode: HashMap::new(),
+            bytecode: HashMap::with_hasher(RandomState::default()),
             bytecode_rx,
             get_type_rx,
             get_field_rx,
@@ -297,7 +299,7 @@ impl Extools {
         Ok(self.get_type_rx.recv_timeout(RECV_TIMEOUT)?.0)
     }
 
-    pub fn get_all_fields(&self, reference: Ref) -> Result<HashMap<String, ValueText>, Box<dyn Error>> {
+    pub fn get_all_fields(&self, reference: Ref) -> Result<HashMap<String, ValueText, RandomState>, Box<dyn Error>> {
         self.sender.send(GetAllFields(reference));
         Ok(self.get_field_rx.recv_timeout(RECV_TIMEOUT)?.0)
     }

--- a/src/langserver/debugger/extools_types.rs
+++ b/src/langserver/debugger/extools_types.rs
@@ -8,6 +8,8 @@
 use std::collections::HashMap;
 use serde_json::Value as Json;
 
+use ahash::RandomState;
+
 // ----------------------------------------------------------------------------
 // Extools data structures
 
@@ -328,7 +330,7 @@ impl Request for GetAllFields {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct GetAllFieldsResponse(pub HashMap<String, ValueText>);
+pub struct GetAllFieldsResponse(pub HashMap<String, ValueText, RandomState>);
 
 impl Response for GetAllFieldsResponse {
     const TYPE: &'static str = "get all fields";

--- a/src/langserver/document.rs
+++ b/src/langserver/document.rs
@@ -14,11 +14,13 @@ use lsp_types::{TextDocumentItem, TextDocumentIdentifier,
 
 use super::{invalid_request, url_to_path};
 
+use ahash::RandomState;
+
 /// A store for the contents of currently-open documents, with appropriate
 /// fallback for documents which are not currently open.
 #[derive(Default)]
 pub struct DocumentStore {
-    map: HashMap<Url, Document>,
+    map: HashMap<Url, Document, RandomState>,
 }
 
 impl DocumentStore {

--- a/src/langserver/find_references.rs
+++ b/src/langserver/find_references.rs
@@ -6,8 +6,10 @@ use dm::Location;
 use dm::objtree::*;
 use dm::ast::*;
 
+use ahash::RandomState;
+
 pub struct ReferencesTable {
-    uses: HashMap<SymbolId, References>,
+    uses: HashMap<SymbolId, References, RandomState>,
     symbols: SymbolIdSource,
 }
 
@@ -20,7 +22,7 @@ struct References {
 impl ReferencesTable {
     pub fn new(objtree: &ObjectTree) -> Self {
         let mut tab = ReferencesTable {
-            uses: Default::default(),
+            uses: HashMap::with_hasher(RandomState::default()),
             symbols: SymbolIdSource::new(SymbolIdCategory::LocalVars),
         };
 
@@ -132,12 +134,12 @@ struct WalkProc<'o> {
     objtree: &'o ObjectTree,
     ty: TypeRef<'o>,
     proc: Option<ProcRef<'o>>,
-    local_vars: HashMap<String, Local<'o>>,
+    local_vars: HashMap<String, Local<'o>, RandomState>,
 }
 
 impl<'o> WalkProc<'o> {
     fn from_proc(tab: &'o mut ReferencesTable, objtree: &'o ObjectTree, proc: ProcRef<'o>) -> Self {
-        let mut local_vars = HashMap::new();
+        let mut local_vars = HashMap::with_hasher(RandomState::default());
         local_vars.insert("global".to_owned(), Local {
             ty: StaticType::Type(objtree.root()),
             symbol: objtree.root().id,
@@ -173,7 +175,7 @@ impl<'o> WalkProc<'o> {
     }
 
     fn from_ty(tab: &'o mut ReferencesTable, objtree: &'o ObjectTree, ty: TypeRef<'o>) -> Self {
-        let mut local_vars = HashMap::new();
+        let mut local_vars = HashMap::with_hasher(RandomState::default());
         local_vars.insert("global".to_owned(), Local {
             ty: StaticType::Type(objtree.root()),
             symbol: objtree.root().id,

--- a/src/tools/Cargo.toml
+++ b/src/tools/Cargo.toml
@@ -13,6 +13,8 @@ ndarray = "0.13.0"
 rand = "0.7.0"
 dreammaker = { path = "../dreammaker" }
 lodepng = "3.0.0"
+indexmap = "1.7.0"
+ahash = "0.7.6"
 
 [dependencies.bytemuck]
 version = "1.5"
@@ -21,10 +23,6 @@ features = ["derive"]
 [dependencies.bumpalo]
 version = "3.0.0"
 features = ["collections"]
-
-[dependencies.linked-hash-map]
-git = "https://github.com/SpaceManiac/linked-hash-map"
-branch = "get-key-value"
 
 [dependencies.png]
 version = "0.16.0"

--- a/src/tools/dmm.rs
+++ b/src/tools/dmm.rs
@@ -5,7 +5,8 @@ use std::io;
 use std::fmt;
 
 use ndarray::{self, Array3, Axis};
-use linked_hash_map::LinkedHashMap;
+use indexmap::IndexMap;
+use ahash::RandomState;
 
 use dm::DMError;
 use dm::constants::Constant;
@@ -118,11 +119,18 @@ pub struct ZLevel<'a> {
 }
 
 // TODO: port to ast::Prefab<Constant>
-#[derive(Debug, Default, Hash, Eq, PartialEq, Clone)]
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct Prefab {
     pub path: String,
     // insertion order, sort of most of the time alphabetical but not quite
-    pub vars: LinkedHashMap<String, Constant>,
+    pub vars: IndexMap<String, Constant, RandomState>,
+}
+
+impl std::hash::Hash for Prefab {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		self.path.hash(state);
+        self.vars.keys().for_each(|key| {key.hash(state)});
+	}
 }
 
 impl Map {

--- a/src/tools/dmm.rs
+++ b/src/tools/dmm.rs
@@ -127,10 +127,10 @@ pub struct Prefab {
 }
 
 impl std::hash::Hash for Prefab {
-	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-		self.path.hash(state);
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.path.hash(state);
         self.vars.keys().for_each(|key| {key.hash(state)});
-	}
+    }
 }
 
 impl Map {

--- a/src/tools/lib.rs
+++ b/src/tools/lib.rs
@@ -8,7 +8,6 @@ extern crate lodepng;
 extern crate inflate;
 
 #[macro_use] extern crate bytemuck;
-extern crate linked_hash_map;
 extern crate rand;
 extern crate bumpalo;
 

--- a/src/tools/minimap.rs
+++ b/src/tools/minimap.rs
@@ -10,6 +10,8 @@ use crate::dmi::{Dir, Image};
 use crate::render_passes::RenderPass;
 use crate::icon_cache::IconCache;
 
+use ahash::RandomState;
+
 const TILE_SIZE: u32 = 32;
 
 // ----------------------------------------------------------------------------
@@ -23,7 +25,7 @@ pub struct Context<'a> {
     pub min: (usize, usize),
     pub max: (usize, usize),
     pub render_passes: &'a [Box<dyn RenderPass>],
-    pub errors: &'a RwLock<HashSet<String>>,
+    pub errors: &'a RwLock<HashSet<String, RandomState>>,
     pub bump: &'a bumpalo::Bump,
 }
 
@@ -197,7 +199,7 @@ fn get_atom_list<'a>(
     objtree: &'a ObjectTree,
     prefabs: &'a [Prefab],
     render_passes: &[Box<dyn RenderPass>],
-    errors: &RwLock<HashSet<String>>,
+    errors: &RwLock<HashSet<String, RandomState>>,
 ) -> Vec<Atom<'a>> {
     let mut result = Vec::new();
 


### PR DESCRIPTION
ahash is straight up faster for string hashing
indexmap is at least maintained and has methods that we use, also faster iteration.

before:
![before](https://user-images.githubusercontent.com/56778689/139512534-2e9b3a48-25c9-46bf-ba14-972b904d012d.png)
after:
![image](https://user-images.githubusercontent.com/56778689/139512587-b821d0c6-f99f-4bae-ad53-b5adbf65dc9a.png)
