### PR TITLE
Linter checks for the switch(rand(L, H)) pattern

### DIFF
--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1484,7 +1484,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 for (case, ref block) in cases.iter() {
                     let mut scoped_locals = local_vars.clone();
                     if let [dm::ast::Case::Exact(Expression::BinaryOp{op: BinaryOp::Or, ..})] = case.elem[..] {
-                        error(case.location, format!("Elements in a switch-case branch separated by ||, this is likely in error and should be replaced by a comma"))
+                        error(case.location, "Elements in a switch-case branch separated by ||, this is likely in error and should be replaced by a comma")
                             .set_severity(Severity::Warning)
                             .register(self.context);
                     }

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1483,6 +1483,11 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 self.visit_expression(location, input, None, local_vars);
                 for (case, ref block) in cases.iter() {
                     let mut scoped_locals = local_vars.clone();
+                    if let [dm::ast::Case::Exact(Expression::BinaryOp{op: BinaryOp::Or, ..})] = case.elem[..] {
+                        error(case.location, format!("Elements in a switch-case branch separated by ||, this is likely in error and should be replaced by a comma"))
+                            .set_severity(Severity::Warning)
+                            .register(self.context);
+                    }
                     for case_part in case.elem.iter() {
                         match case_part {
                             dm::ast::Case::Exact(expr) => { self.visit_expression(case.location, expr, None, &mut scoped_locals); },

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -15,6 +15,8 @@ use ahash::RandomState;
 
 mod type_expr;
 use type_expr::TypeExpr;
+mod switch_rand_range;
+use switch_rand_range::check_switch_rand_range;
 
 #[doc(hidden)]  // Intended for the tests only.
 pub mod test_helpers;
@@ -1475,6 +1477,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 self.inside_newcontext = self.inside_newcontext.wrapping_sub(1);
             },
             Statement::Switch { input, cases, default } => {
+                check_switch_rand_range(input, cases, default, location, self.context);
                 let mut allterm = ControlFlow::alltrue();
                 self.visit_control_condition(location, input);
                 self.visit_expression(location, input, None, local_vars);

--- a/crates/dreamchecker/src/switch_rand_range.rs
+++ b/crates/dreamchecker/src/switch_rand_range.rs
@@ -1,0 +1,113 @@
+
+use std::borrow::Borrow;
+
+use dm::{Context, DMError, Location, Severity};
+use dm::ast::*;
+
+/**
+ * Checks for mistakes in switches of the form `switch(rand(L, H))`.
+ * If some cases lie outside of the [L, H] range or the whole [L, H] range is not covered by all the cases a warning is issued.
+ */
+pub fn check_switch_rand_range(
+        input: &Box<Expression>,
+        cases: &Box<[(Spanned<Vec<Case>>, Block)]>,
+        default: &Option<Block>,
+        location: Location,
+        context: &Context,
+    ) {
+    let (rand_start, rand_end) = if let Some(range) = get_rand_range(input) {
+        range
+    }
+    else {
+        return;
+    };
+
+    let mut case_ranges = vec![];
+    case_ranges.reserve(cases.len());
+    for case_block in cases.iter() {
+        let location = case_block.0.location;
+        for case in case_block.0.elem.iter() {
+            if let Some((start, end)) = get_case_range(&case, location) {
+                let start = start.ceil() as i32;
+                let end = end.floor() as i32;
+                if start <= rand_end && end >= rand_start {
+                    case_ranges.push((start, end));
+                }
+                else {
+                    DMError::new(location, format!("Case range '{} to {}' will never trigger as it is outside the rand() range {} to {}", start, end, rand_start, rand_end))
+                        .with_component(dm::Component::DreamChecker)
+                        .set_severity(Severity::Warning)
+                        .register(context);
+                }
+            }
+        }
+    }
+
+    if default.is_some() { // covers the whole range directly so no need to check for gaps
+        return;
+    }
+
+    case_ranges.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut first_uncovered = rand_start;
+    for (start, end) in case_ranges.iter() {
+        if *start > first_uncovered {
+            break;
+        }
+        else {
+            first_uncovered = std::cmp::max(first_uncovered, end + 1);
+        }
+    }
+
+    if first_uncovered <= rand_end {
+        DMError::new(location, format!("Switch branches on rand() with range {} to {} but no case branch triggers for {}", rand_start, rand_end, first_uncovered))
+            .with_component(dm::Component::DreamChecker)
+            .set_severity(Severity::Warning)
+            .register(context);
+    }
+}
+
+fn get_case_range(case: &Case, location: Location) -> Option<(f32, f32)> {
+    match case {
+        Case::Exact(ref value) => {
+            let value = value.to_owned().simple_evaluate(location).ok()?.to_float()?;
+            Some((value, value))
+        },
+        Case::Range(ref min, ref max) => {
+            let min = min.to_owned().simple_evaluate(location).ok()?.to_float()?;
+            let max = max.to_owned().simple_evaluate(location).ok()?.to_float()?;
+            Some((min, max))
+        },
+    }
+}
+
+fn get_rand_range(maybe_rand: &Expression) -> Option<(i32, i32)> {
+    let (term, location) = match maybe_rand {
+        &Expression::Base { ref term, ref follow } if follow.is_empty() => (&term.elem, term.location),
+        _ => return None,
+    };
+
+    let rand_args: &[Expression] = match term {
+        Term::Call(proc_name, args) if proc_name.as_str() == "rand" => {
+            args.borrow()
+        }
+        _ => return None,
+    };
+
+    let (min, max) = match rand_args {
+        [min, max] => {
+            (
+                min.to_owned().simple_evaluate(location).ok()?.to_float()?,
+                max.to_owned().simple_evaluate(location).ok()?.to_float()?
+            )
+        },
+        [max] => {
+            (
+                0.,
+                max.to_owned().simple_evaluate(location).ok()?.to_float()?
+            )
+        },
+        _ => return None,
+    };
+
+    Some((min.ceil() as i32, max.floor() as i32))
+}

--- a/crates/dreamchecker/src/switch_rand_range.rs
+++ b/crates/dreamchecker/src/switch_rand_range.rs
@@ -1,24 +1,22 @@
-
 use std::borrow::Borrow;
 
-use dm::{Context, DMError, Location, Severity};
 use dm::ast::*;
+use dm::{Context, DMError, Location, Severity};
 
 /**
  * Checks for mistakes in switches of the form `switch(rand(L, H))`.
  * If some cases lie outside of the [L, H] range or the whole [L, H] range is not covered by all the cases a warning is issued.
  */
 pub fn check_switch_rand_range(
-        input: &Box<Expression>,
-        cases: &Box<[(Spanned<Vec<Case>>, Block)]>,
-        default: &Option<Block>,
-        location: Location,
-        context: &Context,
-    ) {
+    input: &Box<Expression>,
+    cases: &Box<[(Spanned<Vec<Case>>, Block)]>,
+    default: &Option<Block>,
+    location: Location,
+    context: &Context,
+) {
     let (rand_start, rand_end) = if let Some(range) = get_rand_range(input) {
         range
-    }
-    else {
+    } else {
         return;
     };
 
@@ -32,8 +30,7 @@ pub fn check_switch_rand_range(
                 let end = end.floor() as i32;
                 if start <= rand_end && end >= rand_start {
                     case_ranges.push((start, end));
-                }
-                else {
+                } else {
                     DMError::new(location, format!("Case range '{} to {}' will never trigger as it is outside the rand() range {} to {}", start, end, rand_start, rand_end))
                         .with_component(dm::Component::DreamChecker)
                         .set_severity(Severity::Warning)
@@ -43,7 +40,8 @@ pub fn check_switch_rand_range(
         }
     }
 
-    if default.is_some() { // covers the whole range directly so no need to check for gaps
+    if default.is_some() {
+        // covers the whole range directly so no need to check for gaps
         return;
     }
 
@@ -52,60 +50,66 @@ pub fn check_switch_rand_range(
     for (start, end) in case_ranges.iter() {
         if *start > first_uncovered {
             break;
-        }
-        else {
+        } else {
             first_uncovered = std::cmp::max(first_uncovered, end + 1);
         }
     }
 
     if first_uncovered <= rand_end {
-        DMError::new(location, format!("Switch branches on rand() with range {} to {} but no case branch triggers for {}", rand_start, rand_end, first_uncovered))
-            .with_component(dm::Component::DreamChecker)
-            .set_severity(Severity::Warning)
-            .register(context);
+        DMError::new(
+            location,
+            format!(
+                "Switch branches on rand() with range {} to {} but no case branch triggers for {}",
+                rand_start, rand_end, first_uncovered
+            ),
+        )
+        .with_component(dm::Component::DreamChecker)
+        .set_severity(Severity::Warning)
+        .register(context);
     }
 }
 
 fn get_case_range(case: &Case, location: Location) -> Option<(f32, f32)> {
     match case {
         Case::Exact(ref value) => {
-            let value = value.to_owned().simple_evaluate(location).ok()?.to_float()?;
+            let value = value
+                .to_owned()
+                .simple_evaluate(location)
+                .ok()?
+                .to_float()?;
             Some((value, value))
-        },
+        }
         Case::Range(ref min, ref max) => {
             let min = min.to_owned().simple_evaluate(location).ok()?.to_float()?;
             let max = max.to_owned().simple_evaluate(location).ok()?.to_float()?;
             Some((min, max))
-        },
+        }
     }
 }
 
 fn get_rand_range(maybe_rand: &Expression) -> Option<(i32, i32)> {
     let (term, location) = match maybe_rand {
-        &Expression::Base { ref term, ref follow } if follow.is_empty() => (&term.elem, term.location),
+        &Expression::Base {
+            ref term,
+            ref follow,
+        } if follow.is_empty() => (&term.elem, term.location),
         _ => return None,
     };
 
     let rand_args: &[Expression] = match term {
-        Term::Call(proc_name, args) if proc_name.as_str() == "rand" => {
-            args.borrow()
-        }
+        Term::Call(proc_name, args) if proc_name.as_str() == "rand" => args.borrow(),
         _ => return None,
     };
 
     let (min, max) = match rand_args {
-        [min, max] => {
-            (
-                min.to_owned().simple_evaluate(location).ok()?.to_float()?,
-                max.to_owned().simple_evaluate(location).ok()?.to_float()?
-            )
-        },
-        [max] => {
-            (
-                0.,
-                max.to_owned().simple_evaluate(location).ok()?.to_float()?
-            )
-        },
+        [min, max] => (
+            min.to_owned().simple_evaluate(location).ok()?.to_float()?,
+            max.to_owned().simple_evaluate(location).ok()?.to_float()?,
+        ),
+        [max] => (
+            0.,
+            max.to_owned().simple_evaluate(location).ok()?.to_float()?,
+        ),
         _ => return None,
     };
 

--- a/crates/dreamchecker/tests/switch_rand_range_tests.rs
+++ b/crates/dreamchecker/tests/switch_rand_range_tests.rs
@@ -1,0 +1,108 @@
+
+extern crate dreamchecker as dc;
+
+use dc::test_helpers::*;
+
+pub const SWITCH_RAND_INCOMPLETE_ERRORS: &[(u32, u16, &str)] = &[
+    (5, 9, "Case range '0 to 0' will never trigger as it is outside the rand() range 1 to 3"),
+    (2, 5, "Switch branches on rand() with range 1 to 3 but no case branch triggers for 3"),
+];
+
+#[test]
+fn switch_rand_incomplete() {
+    let code = r##"
+/proc/test()
+    switch(rand(1, 3))
+        if(0)
+            return
+        if(1)
+            return
+        if(2)
+            return
+"##.trim();
+    check_errors_match(code, SWITCH_RAND_INCOMPLETE_ERRORS);
+}
+
+
+pub const SWITCH_RAND_WITH_EVALUATION_ERRORS: &[(u32, u16, &str)] = &[
+    (2, 5, "Switch branches on rand() with range 2 to 3 but no case branch triggers for 3"),
+];
+
+#[test]
+fn switch_rand_with_evaluation() {
+    let code = r##"
+/proc/test()
+    switch(rand(1 + 1, 4 - 1))
+        if(3 - 1)
+            return
+"##.trim();
+    check_errors_match(code, SWITCH_RAND_WITH_EVALUATION_ERRORS);
+}
+
+
+#[test]
+fn switch_rand_case_ranges() {
+    let code = r##"
+/proc/test()
+    switch(rand(1, 4))
+        if(1 to 2)
+            return
+        if(3, 4)
+            return
+"##.trim();
+    check_errors_match(code, &[]);
+}
+
+
+pub const SWITCH_RAND_DEFAULT_ERRORS: &[(u32, u16, &str)] = &[
+    (5, 9, "Case range '5 to 5' will never trigger as it is outside the rand() range 1 to 4"),
+];
+
+#[test]
+fn switch_rand_default() {
+    let code = r##"
+/proc/test()
+    switch(rand(1, 4))
+        if(5)
+            return
+        if(2)
+            return
+        else
+            return
+"##.trim();
+    check_errors_match(code, SWITCH_RAND_DEFAULT_ERRORS);
+}
+
+
+
+#[test]
+fn switch_rand_floats() {
+    let code = r##"
+/proc/test()
+    switch(rand(1, 4))
+        if(0.5 to 1.5)
+            return
+        if(2)
+            return
+        if(2.5 to 400)
+            return
+"##.trim();
+    check_errors_match(code, &[]);
+}
+
+
+
+#[test]
+fn switch_rand_out_of_order() {
+    let code = r##"
+/proc/test()
+    switch(rand(1, 4))
+        if(3 to 4)
+            return
+        if(2)
+            return
+        if(1)
+            return
+"##.trim();
+    check_errors_match(code, &[]);
+}


### PR DESCRIPTION
A pattern such as
```
switch(rand(1, 3))
  if(1)
    foo()
  if(2)
    bar()
  if(3)
    baz()
```
is not uncommon in SS13 code. Sadly, it is also not uncommon for people to add new cases to a longer switch of this form and forget to change the `rand` arguments at the top. This PR adds a linter warning for when the `rand` range is not fully covered by the cases and for when a case lies completely outside of the `rand` range.

This currently generates 7 warnings on tgstation master. Sadly, it is (at least to me) not quite clear if the omissions of a part of the `rand` range are intentional there or not. However, I believe that even if they are intentional it is worth adding the missing part of the range as a case with empty body explicitly to make the intent clear to future developers.

As a less related (but perhaps more important) addition this PR now also adds a warning for switch branches of the form `if(X || Y)` which is pretty much always a mistake and should instead be `if(X, Y)`. This lint generates 5 warnings on current tg code, seemingly all being actual mistakes.