### PR TITLE
Fix Sleep/Purity checks being skipped under certain overrides

### DIFF
--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -695,7 +695,8 @@ impl<'o> AnalyzeObjectTree<'o> {
                             .with_blocking_builtins(self.sleeping_procs.get_violators(*child_violator).unwrap())
                             .register(self.context)
                     }
-                } else if let Some(calledvec) = self.call_tree.get(&nextproc) {
+                } 
+                if let Some(calledvec) = self.call_tree.get(&nextproc) {
                     for (proccalled, location, new_context) in calledvec.iter() {
                         let mut newstack = callstack.clone();
                         newstack.add_step(*proccalled, *location, *new_context);
@@ -745,7 +746,8 @@ impl<'o> AnalyzeObjectTree<'o> {
                             .with_blocking_builtins(self.impure_procs.get_violators(*child_violator).unwrap())
                             .register(self.context)
                     }
-                } else if let Some(calledvec) = self.call_tree.get(&nextproc) {
+                } 
+                if let Some(calledvec) = self.call_tree.get(&nextproc) {
                     for (proccalled, location, new_context) in calledvec.iter() {
                         let mut newstack = callstack.clone();
                         newstack.add_step(*proccalled, *location, *new_context);

--- a/crates/dreamchecker/tests/sleep_pure_tests.rs
+++ b/crates/dreamchecker/tests/sleep_pure_tests.rs
@@ -170,7 +170,7 @@ fn sleep5() {
         sleep(1)
 
 /datum/hijack/proxy()
-    sleep(1)
+        sleep(1)
 "##.trim();
     check_errors_match(code, SLEEP_ERROR5);
 }

--- a/crates/dreamchecker/tests/sleep_pure_tests.rs
+++ b/crates/dreamchecker/tests/sleep_pure_tests.rs
@@ -149,6 +149,32 @@ fn sleep4() {
     check_errors_match(code, SLEEP_ERROR4);
 }
 
+// Test overrides and for regression of issue #267
+pub const SLEEP_ERROR5: &[(u32, u16, &str)] = &[
+        (7, 19, "/datum/sub/proc/checker sets SpacemanDMM_should_not_sleep but calls blocking proc /proc/sleeper"),
+];
+
+#[test]
+fn sleep5() {
+    let code = r##"
+/datum/proc/checker()
+        set SpacemanDMM_should_not_sleep = 1
+
+/datum/proc/proxy()
+        sleeper()
+
+/datum/sub/checker()
+        proxy()
+
+/proc/sleeper()
+        sleep(1)
+
+/datum/hijack/proxy()
+    sleep(1)
+"##.trim();
+    check_errors_match(code, SLEEP_ERROR5);
+}
+
 pub const PURE_ERRORS: &[(u32, u16, &str)] = &[
     (12, 16, "/mob/proc/test2 sets SpacemanDMM_should_be_pure but calls a /proc/impure that does impure operations"),
 ];


### PR DESCRIPTION
Long overdue PR for #267 and as discuted on coderbus ages ago back then

TL;DR is, there being an override one way or another shouldn't prevent you from checking children too

Discovered on CM-SS13 as we had a controller held up by sleep randomly in production, and no amount of hammering SHOULD_NOT_SLEEP checks seemed to trip anything !

As additional and separate note, and as we discussed back then on coderbus, there are more situations with assumptions of types that mean SpacemanDMM will miss out on a big part of the violators. It's actually for best, because "properly" checking is near impossible on SS13 due to double dispatch constructs just about erasing the "actual" types. This resulted in about 25,000 violating procs when fixing it for CM-SS13, for example...