### PR TITLE
Adds /dm_filter hidden type to dreammaker builtins

### DIFF
--- a/crates/dreammaker/src/builtins.rs
+++ b/crates/dreammaker/src/builtins.rs
@@ -590,7 +590,7 @@ pub fn register_builtins(tree: &mut ObjectTreeBuilder) {
         savefile    yes   yes          yes   yes  yes  yes
         client      yes   yes          yes   yes  yes  yes  yes
 
-        All other root types have an implicit `parent_type = /datum`.
+        Most other root types have an implicit `parent_type = /datum`.
         */
         datum;
         datum/var/const/type;  // not editable
@@ -1063,6 +1063,34 @@ pub fn register_builtins(tree: &mut ObjectTreeBuilder) {
         savefile/proc/ImportText(/* path=cd, file */);
         savefile/proc/Lock(timeout);
         savefile/proc/Unlock();
+
+        //512 stuff
+
+        // /dm_filter is a hidden type that can be used to manipulate filter
+        // instances without using the runtime search operator (:). It does
+        // not descend from datum, cannot be subtyped, and can only be created
+        // successfully by a valid call to proc/filter(...). All filter types
+        // create the same kind of /dm_filter, but with different properties.
+        dm_filter;
+        dm_filter/var/const/type;
+        dm_filter/var/x;
+        dm_filter/var/y;
+        dm_filter/var/icon;
+        dm_filter/var/render_source;
+        dm_filter/var/flags;
+        dm_filter/var/size;
+        dm_filter/var/threshold;
+        dm_filter/var/offset;
+        dm_filter/var/alpha;
+        dm_filter/var/color;
+        dm_filter/var/space;
+        dm_filter/var/transform;
+        dm_filter/var/blend_mode;
+        dm_filter/var/density;
+        dm_filter/var/factor;
+        dm_filter/var/repeat;
+        dm_filter/var/radius;
+        dm_filter/var/falloff;
 
         // 513 stuff
         proc/arctan(A,B);


### PR DESCRIPTION
reference to this type -
<https://www.byond.com/forum/post/2544111#comment25180960>

After some cursory poking, /dm_filter is a hidden type that can be used to manipulate filter instances without using the runtime search operator (:). There is no official reference material for it. It does not descend from datum, cannot be subtyped, and can only be created *successfully* by a valid call to proc/filter(...).  All filter types create the same kind of /dm_filter but with different properties, of which I believe type is the only const.

A contributor on bay tried to use it but checker doesn't know about it. I'm not familiar with the guts of suite, but I think this is all that's necessary?