### PR TITLE
Add [u8] read/write functions to Image/IconFile/Metadata

### DIFF
--- a/crates/dmm-tools/src/dmi.rs
+++ b/crates/dmm-tools/src/dmi.rs
@@ -30,11 +30,11 @@ pub struct IconFile {
 
 impl IconFile {
     pub fn from_file(path: &Path) -> io::Result<IconFile> {
-        Self::from_raw(std::fs::read(path)?)
+        Self::from_bytes(&std::fs::read(path)?)
     }
 
-    pub fn from_raw<Bytes: AsRef<[u8]>>(data: Bytes) -> io::Result<IconFile> {
-        let (bitmap, metadata) = Metadata::from_raw(data)?;
+    pub fn from_bytes(data: &[u8]) -> io::Result<IconFile> {
+        let (bitmap, metadata) = Metadata::from_bytes(data)?;
         Ok(IconFile {
             metadata,
             image: Image::from_rgba(bitmap),
@@ -129,11 +129,11 @@ impl Image {
         }
     }
 
-    /// Read an `Image` from a [u8] array.
+    /// Read an `Image` from a `&[u8]` slice.
     ///
-    /// Prefer to call `IconFile::from_file`, which can read both metadata and
+    /// Prefer to call `IconFile::from_bytes`, which can read both metadata and
     /// image contents at one time.
-    pub fn from_raw<B: AsRef<[u8]>>(data: B) -> io::Result<Image> {
+    pub fn from_bytes(data: &[u8]) -> io::Result<Image> {
         let mut decoder = Decoder::new();
         decoder.info_raw_mut().colortype = ColorType::RGBA;
         decoder.info_raw_mut().set_bitdepth(8);
@@ -154,7 +154,7 @@ impl Image {
     /// image contents at one time.
     pub fn from_file(path: &Path) -> io::Result<Image> {
         let path = &::dm::fix_case(path);
-        Self::from_raw(std::fs::read(path)?)
+        Self::from_bytes(&std::fs::read(path)?)
     }
 
     #[cfg(feature = "png")]
@@ -165,7 +165,7 @@ impl Image {
             encoder.set_depth(::png::BitDepth::Eight);
             let mut writer = encoder.write_header()?;
             // TODO: metadata with write_chunk()
-    
+
             writer.write_image_data(bytemuck::cast_slice(self.data.as_slice().unwrap()))?;
         }
         Ok(())
@@ -177,7 +177,7 @@ impl Image {
     }
 
     #[cfg(feature = "png")]
-    pub fn to_raw(&self) -> io::Result<Vec<u8>> {
+    pub fn to_bytes(&self) -> io::Result<Vec<u8>> {
         let mut vector = Vec::new();
         self.to_write(&mut vector)?;
         Ok(vector)

--- a/crates/dmm-tools/tests/parse_codebase.rs
+++ b/crates/dmm-tools/tests/parse_codebase.rs
@@ -41,13 +41,6 @@ fn parse_all_dmm() {
 }
 
 #[test]
-fn parse_all_dmi() {
-    files_with_extension("dmi", |path| {
-        dmi::Metadata::from_file(path).unwrap();
-    });
-}
-
-#[test]
 fn parse_all_dmi_raw() {
     files_with_extension("dmi", |path| {
         let data = std::fs::read(path).unwrap();

--- a/crates/dmm-tools/tests/parse_codebase.rs
+++ b/crates/dmm-tools/tests/parse_codebase.rs
@@ -46,3 +46,12 @@ fn parse_all_dmi() {
         dmi::Metadata::from_file(path).unwrap();
     });
 }
+
+#[test]
+fn parse_all_dmi_raw() {
+    files_with_extension("dmi", |path| {
+        let data = std::fs::read(path).unwrap();
+        dmi::Metadata::from_raw(data).unwrap();
+    });
+}
+

--- a/crates/dmm-tools/tests/parse_codebase.rs
+++ b/crates/dmm-tools/tests/parse_codebase.rs
@@ -46,4 +46,3 @@ fn parse_all_dmi() {
         dmi::Metadata::from_file(path).unwrap();
     });
 }
-

--- a/crates/dmm-tools/tests/parse_codebase.rs
+++ b/crates/dmm-tools/tests/parse_codebase.rs
@@ -41,10 +41,9 @@ fn parse_all_dmm() {
 }
 
 #[test]
-fn parse_all_dmi_raw() {
+fn parse_all_dmi() {
     files_with_extension("dmi", |path| {
-        let data = std::fs::read(path).unwrap();
-        dmi::Metadata::from_raw(data).unwrap();
+        dmi::Metadata::from_file(path).unwrap();
     });
 }
 

--- a/crates/dreammaker/src/dmi.rs
+++ b/crates/dreammaker/src/dmi.rs
@@ -223,11 +223,11 @@ impl Metadata {
     /// Read the bitmap and DMI metadata from a given file in a single pass.
     pub fn from_file(path: &Path) -> io::Result<(lodepng::Bitmap<lodepng::RGBA>, Metadata)> {
         let path = &crate::fix_case(path);
-        Self::from_raw(std::fs::read(path)?)
+        Self::from_bytes(&std::fs::read(path)?)
     }
 
     /// Read a u8 array (raw data of a file) as a DMI into a bitmap and metadata
-    pub fn from_raw<Bytes: AsRef<[u8]>>(data: Bytes) -> io::Result<(lodepng::Bitmap<lodepng::RGBA>, Metadata)> {
+    pub fn from_bytes(data: &[u8]) -> io::Result<(lodepng::Bitmap<lodepng::RGBA>, Metadata)> {
         let mut decoder = Decoder::new();
         decoder.info_raw_mut().colortype = lodepng::ColorType::RGBA;
         decoder.info_raw_mut().set_bitdepth(8);

--- a/crates/dreammaker/src/dmi.rs
+++ b/crates/dreammaker/src/dmi.rs
@@ -223,21 +223,10 @@ impl Metadata {
     /// Read the bitmap and DMI metadata from a given file in a single pass.
     pub fn from_file(path: &Path) -> io::Result<(lodepng::Bitmap<lodepng::RGBA>, Metadata)> {
         let path = &crate::fix_case(path);
-        let mut decoder = Decoder::new();
-        decoder.info_raw_mut().colortype = lodepng::ColorType::RGBA;
-        decoder.info_raw_mut().set_bitdepth(8);
-        decoder.remember_unknown_chunks(false);
-        let bitmap = match decoder.decode_file(path) {
-            Ok(::lodepng::Image::RGBA(bitmap)) => bitmap,
-            Ok(_) => return Err(io::Error::new(io::ErrorKind::InvalidData, "not RGBA")),
-            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e)),
-        };
-
-        let metadata = Metadata::from_decoder(bitmap.width as u32, bitmap.height as u32, &decoder);
-        Ok((bitmap, metadata))
+        Self::from_raw(std::fs::read(path)?)
     }
 
-    /// Read a u8 array (raw data of a file) as a DMI
+    /// Read a u8 array (raw data of a file) as a DMI into a bitmap and metadata
     pub fn from_raw<Bytes: AsRef<[u8]>>(data: Bytes) -> io::Result<(lodepng::Bitmap<lodepng::RGBA>, Metadata)> {
         let mut decoder = Decoder::new();
         decoder.info_raw_mut().colortype = lodepng::ColorType::RGBA;


### PR DESCRIPTION
This is so IconDiffBot2 can operate purely in memory.

Metadata::from_raw and IconFile::from_raw take an AsRef<[u8]>
as the sequence of bytes of a valid PNG+DMI file to produce their types.

Image::to_raw gives a Vec<u8> which is just the output from
png::Encoder.

There is no Image::from_raw because there's no reason not to use
IconFile::from_raw, and there is no to_raw for Metadata or IconFile
because they don't support to_file either. IconFile could, but it's
unnecessary.