### PR TITLE
Change panics when parsing a malformed dmi to return a Result instead

### DIFF
--- a/crates/dreammaker/src/dmi.rs
+++ b/crates/dreammaker/src/dmi.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 use lodepng::Decoder;
 
-const VERSION: &str = "4.0";
+const EXPECTED_VERSION_LINE: &str = "version = 4.0";
 
 /// The two-dimensional facing subset of BYOND's direction type.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -358,8 +358,8 @@ fn parse_metadata(data: &str) -> io::Result<Metadata> {
     }
 
     let mut lines = data.lines();
-    let header = (lines.next().map(str::to_string), lines.next().map(str::to_string));
-    let expected_header = (Some("# BEGIN DMI".into()), Some(format!("version = {}", VERSION)));
+    let header = (lines.next(), lines.next());
+    let expected_header = (Some("# BEGIN DMI"), Some(EXPECTED_VERSION_LINE));
     if header != expected_header {
         return Err(
             io::Error::new(


### PR DESCRIPTION
Currently parsing a malformed - but also well-formed, yet ancient - .dmi files results in a panic deep within the guts of SapacemanDMM. That's undesirable, since `.dmi`'s which SpacemanDMM does not understand (yet BYOND dreammaker handles fine) do exist in the wild (see https://github.com/ParadiseSS13/Paradise/pull/17800 for a couple of examples).

I don't think teaching SpacemanDMM of the legacy file formats is worth it, but making it return a Result instead of outright panicking definitely is (and it's much less work than the former).

This is technically a breaking change since it changes the signature of the public `dreammaker::dmi::Metadata::meta_from_str()`. (But it's probably rarely used, and definitely easy to fix at the call site?..)