### PR TITLE
Add a few simple derives to dmi-related structs

### DIFF
--- a/crates/dreammaker/src/dmi.rs
+++ b/crates/dreammaker/src/dmi.rs
@@ -171,7 +171,7 @@ impl Default for Dir {
 }
 
 /// Embedded metadata describing a DMI spritesheet's layout.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Metadata {
     /// The width of the icon in pixels.
     pub width: u32,
@@ -184,7 +184,7 @@ pub struct Metadata {
 }
 
 /// The metadata belonging to a single icon state.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct State {
     /// The state's name, corresponding to the `icon_state` var.
     pub name: String,
@@ -208,7 +208,7 @@ pub enum Dirs {
 }
 
 /// How many frames of animation a state has, and their durations.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Frames {
     /// Without an explicit setting, only one frame.
     One,


### PR DESCRIPTION
Specifically, add `#[derive(Clone, PartialEq)]` to `dmi::{Metadata, State, Frames}`

As per (very weakly authoritative) <https://rust-lang.github.io/api-guidelines/interoperability.html> one should derive all the std's traits whenever feasible. Currently for my own project I only need `State::Clone`. The `PartialEq` is being added for consistency with it being present on other structs already, and the rest of the `std`'s traits feel a bit like an overkill presently (despite what the guidelines might say)