### PR TITLE
Add missing _binobj var for generators

### DIFF
--- a/crates/dreammaker/src/builtins.rs
+++ b/crates/dreammaker/src/builtins.rs
@@ -1130,6 +1130,7 @@ pub fn register_builtins(tree: &mut ObjectTreeBuilder) {
         // 514 stuff
 
         generator;
+        generator/var/_binobj;
         generator/proc/Rand();
         generator/proc/Turn(a);
 


### PR DESCRIPTION
Similar to the database binobj, is a internal object

```
var/generator/gen = generator("circle", 0, 16, NORMAL_RAND)
world.log << "[gen._binobj]"
```

```
Welcome BYOND! (5.0 Public Version 514.1580)
generator("circle", 0, 16, NORMAL_RAND)
```