### PR TITLE
Add call_ext()() support for BYOND 515

### DIFF
--- a/crates/dm-langserver/src/find_references.rs
+++ b/crates/dm-langserver/src/find_references.rs
@@ -520,6 +520,12 @@ impl<'o> WalkProc<'o> {
                 self.visit_arguments(location, args_2);
                 StaticType::None
             },
+            Term::ExternalCall { library_name, function_name, args } => {
+                self.visit_expression(location, library_name, None);
+                self.visit_expression(location, function_name, None);
+                self.visit_arguments(location, args);
+                StaticType::None
+            },
         }
     }
 

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -692,7 +692,7 @@ impl<'o> AnalyzeObjectTree<'o> {
                             .with_blocking_builtins(self.sleeping_procs.get_violators(*child_violator).unwrap())
                             .register(self.context)
                     }
-                } 
+                }
                 if let Some(calledvec) = self.call_tree.get(&nextproc) {
                     for (proccalled, location, new_context) in calledvec.iter() {
                         let mut newstack = callstack.clone();
@@ -743,7 +743,7 @@ impl<'o> AnalyzeObjectTree<'o> {
                             .with_blocking_builtins(self.impure_procs.get_violators(*child_violator).unwrap())
                             .register(self.context)
                     }
-                } 
+                }
                 if let Some(calledvec) = self.call_tree.get(&nextproc) {
                     for (proccalled, location, new_context) in calledvec.iter() {
                         let mut newstack = callstack.clone();
@@ -1861,6 +1861,12 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             Term::DynamicCall(lhs_args, rhs_args) => {
                 self.visit_arguments(location, lhs_args, local_vars);
                 self.visit_arguments(location, rhs_args, local_vars);
+                Analysis::empty()  // TODO
+            },
+            Term::ExternalCall { library_name, function_name, args } => {
+                self.visit_expression(location, library_name, None, local_vars);
+                self.visit_expression(location, function_name, None, local_vars);
+                self.visit_arguments(location, args, local_vars);
                 Analysis::empty()  // TODO
             },
         }

--- a/crates/dreamchecker/tests/call_ext_tests.rs
+++ b/crates/dreamchecker/tests/call_ext_tests.rs
@@ -1,0 +1,29 @@
+extern crate dreamchecker as dc;
+
+use dc::test_helpers::*;
+
+pub const CALL_EXT_MISSING_ARG_ERRORS: &[(u32, u16, &str)] = &[
+    (2, 15, "got ')', expected one of: operator, field access, ','"),
+];
+
+#[test]
+fn call_ext_missing_arg() {
+    let code = r##"
+/proc/f()
+    call_ext(1)(3, 4, 5)
+"##.trim();
+    check_errors_match(code, CALL_EXT_MISSING_ARG_ERRORS);
+}
+
+pub const CALL_EXT_MISSING_CALL_ERRORS: &[(u32, u16, &str)] = &[
+    (2, 19, "got ';', expected one of: '('"),
+];
+
+#[test]
+fn call_ext_missing_call() {
+    let code = r##"
+/proc/f()
+    call_ext(1, 2)
+"##.trim();
+    check_errors_match(code, CALL_EXT_MISSING_CALL_ERRORS);
+}

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -897,6 +897,12 @@ pub enum Term {
     Pick(Box<PickArgs>),
     /// A use of the `call()()` primitive.
     DynamicCall(Box<[Expression]>, Box<[Expression]>),
+    /// A use of the `call_ext()()` primitive.
+    ExternalCall {
+        library_name: Box<Expression>,
+        function_name: Box<Expression>,
+        args: Box<[Expression]>,
+    },
 }
 
 impl Term {

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1984,6 +1984,21 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 require!(self.arguments(&[], "call*")),
             ),
 
+            // term :: 'call_ext' (library_name, function_name) arglist
+            Token::Ident(ref i, _) if i == "call_ext" => {
+                require!(self.exact(Token::Punct(Punctuation::LParen)));
+                let library_name = require!(self.expression());
+                require!(self.exact(Token::Punct(Punctuation::Comma)));
+                let function_name = require!(self.expression());
+                require!(self.exact(Token::Punct(Punctuation::RParen)));
+
+                Term::ExternalCall {
+                    library_name: Box::new(library_name),
+                    function_name: Box::new(function_name),
+                    args: require!(self.arguments(&[], "call_ext*")),
+                }
+            },
+
             // term :: 'input' arglist input_specifier
             Token::Ident(ref i, _) if i == "input" => match self.arguments(&[], "input")? {
                 Some(args) => {


### PR DESCRIPTION
This should be batched with the other 515 changes that are necessary since this can't really ship until DM_VERSION bumps up to 515.

