### PR TITLE
Allows measuring the memory footprint of the Objtree with GetSize trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "attribute-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c124f12ade4e670107b132722d0ad1a5c9790bcbc1b265336369ea05626b4498"
+dependencies = [
+ "attribute-derive-macro",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b217a07446e0fb086f83401a98297e2d81492122f5874db5391bd270a185f88"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "proc-macro-error",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "collection_literals"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc1955a640c4464859ae700fbe48e666da6fdce99ce5fe1acd08dd295889d10"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "deunicode"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +545,8 @@ dependencies = [
  "builtins-proc-macro",
  "color_space",
  "derivative",
+ "get-size",
+ "get-size-derive",
  "guard",
  "indexmap",
  "interval-tree",
@@ -659,6 +706,23 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "get-size"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b61e2dab7eedce93a83ab3468b919873ff16bac5a3e704011ff836d22b2120"
+
+[[package]]
+name = "get-size-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a1bcfb855c1f340d5913ab542e36f25a1c56f57de79022928297632435dec2"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -865,6 +929,12 @@ checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 dependencies = [
  "adler32",
 ]
+
+[[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
 name = "interval-tree"
@@ -1309,6 +1379,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1417,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "quote-use"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e9a38ef862d7fec635661503289062bc5b3035e61859a8de3d3f81823accd2"
+dependencies = [
+ "derive-where",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1531,6 +1624,12 @@ checksum = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
 dependencies = [
  "deunicode",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"

--- a/crates/dreammaker/Cargo.toml
+++ b/crates/dreammaker/Cargo.toml
@@ -20,6 +20,8 @@ color_space = "0.5.3"
 ahash = "0.8.0"
 indexmap = "1.9.1"
 derivative = "2.2.0"
+get-size = "0.1.4"
+get-size-derive = "0.1.3"
 
 [dev-dependencies]
 walkdir = "2.3.2"

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -3,6 +3,9 @@
 //! Most AST types can be pretty-printed using the `Display` trait.
 use std::fmt;
 use std::iter::FromIterator;
+
+use get_size::GetSize;
+use get_size_derive::GetSize;
 use phf::phf_map;
 
 use crate::error::Location;
@@ -17,7 +20,7 @@ pub type SwitchCases = [(Spanned<Vec<Case>>, Block)];
 // Simple enums
 
 /// The unary operators, both prefix and postfix.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, GetSize)]
 pub enum UnaryOp {
     Neg,
     Not,
@@ -78,7 +81,7 @@ impl UnaryOp {
 /// The DM path operators.
 ///
 /// Which path operator is used typically only matters at the start of a path.
-#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, GetSize)]
 pub enum PathOp {
     /// `/` for absolute pathing.
     Slash,
@@ -105,7 +108,7 @@ impl fmt::Display for PathOp {
 }
 
 /// The binary operators.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, GetSize)]
 pub enum BinaryOp {
     Add,
     Sub,
@@ -164,7 +167,7 @@ impl fmt::Display for BinaryOp {
 }
 
 /// The assignment operators, including augmented assignment.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, GetSize)]
 pub enum AssignOp {
     Assign,
     AddAssign,
@@ -249,7 +252,7 @@ pub enum TernaryOp {
 }
 
 /// The possible kinds of access operators for lists
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, GetSize)]
 pub enum ListAccessKind {
     /// `[]`
     Normal,
@@ -258,7 +261,7 @@ pub enum ListAccessKind {
 }
 
 /// The possible kinds of index operators, for both fields and methods.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, GetSize)]
 pub enum PropertyAccessKind {
     /// `a.b`
     Dot,
@@ -292,7 +295,7 @@ impl fmt::Display for PropertyAccessKind {
 /// DM requires referencing proc paths to include whether the target is
 /// declared as a proc or verb, even though the two modes are functionally
 /// identical in many other respects.
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash, GetSize)]
 pub enum ProcDeclKind {
     Proc,
     Verb,
@@ -328,7 +331,7 @@ impl fmt::Display for ProcDeclKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, GetSize)]
 pub enum SettingMode {
     /// As in `set name = "Use"`.
     Assign,
@@ -398,6 +401,7 @@ macro_rules! type_table {
 
 type_table! {
     /// A type specifier for verb arguments and input() calls.
+    #[derive(GetSize)]
     pub struct InputType;
 
     // These values can be known with an invocation such as:
@@ -421,7 +425,7 @@ type_table! {
 }
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Default, GetSize)]
     pub struct VarTypeFlags: u8 {
         // DM flags
         const STATIC = 1 << 0;
@@ -590,8 +594,14 @@ impl fmt::Debug for Ident2 {
     }
 }
 
+impl GetSize for Ident2 {
+    fn get_heap_size(&self) -> usize {
+        self.inner.as_bytes().len()
+    }
+}
+
 /// An AST element with an additional location attached.
-#[derive(Copy, Clone, Eq, Debug)]
+#[derive(Copy, Clone, Eq, Debug, GetSize)]
 pub struct Spanned<T> {
     // TODO: add a Span type and use it here
     pub location: Location,
@@ -643,7 +653,7 @@ impl<'a> fmt::Display for FormatTypePath<'a> {
 // Terms and Expressions
 
 /// A typepath optionally followed by a set of variables.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, GetSize)]
 pub struct Prefab {
     pub path: TypePath,
     pub vars: Box<[(Ident2, Expression)]>,
@@ -681,7 +691,7 @@ where
 }
 
 /// The structure of an expression, a tree of terms and operators.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, GetSize)]
 pub enum Expression {
     /// An expression containing a term directly. The term is evaluated first,
     /// then its follows, then its unary operators in reverse order.
@@ -835,7 +845,7 @@ impl From<Term> for Expression {
 }
 
 /// The structure of a term, the basic building block of the AST.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, GetSize)]
 pub enum Term {
     // Terms with no recursive contents ---------------------------------------
     /// The literal `null`.
@@ -995,14 +1005,14 @@ impl From<Expression> for Term {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, GetSize)]
 pub struct MiniExpr {
     pub ident: Ident2,
     pub fields: Box<[Field]>,
 }
 
 /// An expression part which is applied to a term or another follow.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, GetSize)]
 pub enum Follow {
     /// Index the value by an expression.
     Index(ListAccessKind, Box<Expression>),
@@ -1015,7 +1025,7 @@ pub enum Follow {
 }
 
 /// Like a `Follow` but only supports field accesses.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, GetSize)]
 pub struct Field {
     pub kind: PropertyAccessKind,
     pub ident: Ident2,
@@ -1028,7 +1038,7 @@ impl From<Field> for Follow {
 }
 
 /// A parameter declaration in the header of a proc.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, GetSize)]
 pub struct Parameter {
     pub var_type: VarType,
     pub name: Ident,
@@ -1049,7 +1059,7 @@ impl fmt::Display for Parameter {
 }
 
 /// A type which may be ascribed to a `var`.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, GetSize)]
 pub struct VarType {
     pub flags: VarTypeFlags,
     pub type_path: TreePath,
@@ -1161,7 +1171,7 @@ impl VarSuffix {
 pub type Block = Box<[Spanned<Statement>]>;
 
 /// A statement in a proc body.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, GetSize)]
 pub enum Statement {
     Expr(Expression),
     Return(Option<Expression>),
@@ -1221,20 +1231,20 @@ pub enum Statement {
     Crash(Option<Expression>),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, GetSize)]
 pub struct VarStatement {
     pub var_type: VarType,
     pub name: Ident,
     pub value: Option<Expression>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, GetSize)]
 pub enum Case {
     Exact(Expression),
     Range(Expression, Expression),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, GetSize)]
 pub struct ForListStatement {
     pub var_type: Option<VarType>,
     pub name: Ident2,
@@ -1245,7 +1255,7 @@ pub struct ForListStatement {
     pub block: Block,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, GetSize)]
 pub struct ForRangeStatement {
     pub var_type: Option<VarType>,
     pub name: Ident2,

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -23,9 +23,10 @@ pub type Arguments = [(Constant, Option<Constant>)];
 /// An absolute typepath and optional variables.
 ///
 /// The path may involve `/proc` or `/verb` references.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, GetSize)]
 pub struct Pop {
     pub path: TreePath,
+    #[get_size(size_fn = heap_size_of_index_map)]
     pub vars: IndexMap<Ident, Constant, RandomState>,
 }
 
@@ -60,12 +61,6 @@ impl From<TreePath> for Pop {
 impl fmt::Display for Pop {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}{}", FormatTreePath(&self.path), FormatVars(&self.vars))
-    }
-}
-
-impl GetSize for Pop {
-    fn get_heap_size(&self) -> usize {
-        self.path.get_heap_size() + heap_size_of_index_map(&self.vars)
     }
 }
 

--- a/crates/dreammaker/src/docs.rs
+++ b/crates/dreammaker/src/docs.rs
@@ -2,8 +2,11 @@
 
 use std::fmt;
 
+use get_size::GetSize;
+use get_size_derive::GetSize;
+
 /// A collection of documentation comments targeting the same item.
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq, GetSize)]
 pub struct DocCollection {
     elems: Vec<DocComment>,
     pub builtin_docs: BuiltinDocs,
@@ -60,7 +63,7 @@ impl DocCollection {
 }
 
 /// A documentation comment.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, GetSize)]
 pub struct DocComment {
     pub kind: CommentKind,
     pub target: DocTarget,
@@ -95,7 +98,7 @@ impl fmt::Display for DocComment {
 }
 
 /// The possible documentation comment kinds.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, GetSize)]
 pub enum CommentKind {
     /// A block `/** */` comment.
     Block,
@@ -197,7 +200,7 @@ fn is_empty(text: &str, ignore_char: char) -> bool {
 }
 
 /// The possible items that a documentation comment may target.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, GetSize)]
 pub enum DocTarget {
     /// Starting with `*` or `/`, referring to the following item.
     FollowingItem,
@@ -206,7 +209,7 @@ pub enum DocTarget {
 }
 
 /// Information about where builtin docs can be found.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, GetSize)]
 pub enum BuiltinDocs {
     None,
     /// A DM reference hash such as "/DM/vars".

--- a/crates/dreammaker/src/error.rs
+++ b/crates/dreammaker/src/error.rs
@@ -17,7 +17,7 @@ use crate::config::Config;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct FileId(u16);
 
-impl GetSize for FileId{}
+impl GetSize for FileId {}
 
 const FILEID_BUILTINS: FileId = FileId(0x0000);
 const FILEID_MIN: FileId = FileId(0x0001);

--- a/crates/dreammaker/src/error.rs
+++ b/crates/dreammaker/src/error.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 
 use ahash::RandomState;
 
+use get_size::GetSize;
+use get_size_derive::GetSize;
 use termcolor::{ColorSpec, Color};
 
 use crate::config::Config;
@@ -14,6 +16,8 @@ use crate::config::Config;
 /// An identifier referring to a loaded file.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct FileId(u16);
+
+impl GetSize for FileId{}
 
 const FILEID_BUILTINS: FileId = FileId(0x0000);
 const FILEID_MIN: FileId = FileId(0x0001);
@@ -273,7 +277,7 @@ impl Context {
 // Location handling
 
 /// File, line, and column information for an error.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, GetSize)]
 pub struct Location {
     /// The index into the file table.
     pub file: FileId,

--- a/crates/dreammaker/src/lib.rs
+++ b/crates/dreammaker/src/lib.rs
@@ -199,9 +199,11 @@ pub fn detect_environment_default() -> std::io::Result<Option<std::path::PathBuf
     }))
 }
 
-pub(crate) fn heap_size_of_index_map<K, V>(index_map: &IndexMap<K, V, RandomState>) -> usize where
+fn heap_size_of_index_map<K, V>(index_map: &IndexMap<K, V, RandomState>) -> usize
+where
     K: GetSize,
-    V: GetSize, {
+    V: GetSize,
+{
     let mut total = 0;
 
     for (k, v) in index_map.iter() {

--- a/crates/dreammaker/src/objtree.rs
+++ b/crates/dreammaker/src/objtree.rs
@@ -3,8 +3,13 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+use get_size::GetSize;
+use get_size_derive::GetSize;
+
 use indexmap::IndexMap;
 use ahash::RandomState;
+
+use crate::heap_size_of_index_map;
 
 use super::ast::{Expression, VarType, VarTypeBuilder, VarSuffix, PathOp, Parameter, Block, ProcDeclKind, Ident};
 use super::constants::Constant;
@@ -17,6 +22,8 @@ use super::{DMError, Location, Context, Severity};
 /// An identifier referring to a symbol in the object tree.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct SymbolId(u32);
+
+impl GetSize for SymbolId{}
 
 #[derive(Debug)]
 pub struct SymbolIdSource(SymbolId);
@@ -47,14 +54,14 @@ impl SymbolIdSource {
 
 pub type Vars = IndexMap<String, Constant, RandomState>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, GetSize)]
 pub struct VarDeclaration {
     pub var_type: VarType,
     pub location: Location,
     pub id: SymbolId,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, GetSize)]
 pub struct VarValue {
     pub location: Location,
     /// Syntactic value, as specified in the source.
@@ -65,13 +72,13 @@ pub struct VarValue {
     pub docs: DocCollection,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, GetSize)]
 pub struct TypeVar {
     pub value: VarValue,
     pub declaration: Option<VarDeclaration>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, GetSize)]
 pub struct ProcDeclaration {
     pub location: Location,
     pub kind: ProcDeclKind,
@@ -80,7 +87,7 @@ pub struct ProcDeclaration {
     pub is_protected: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, GetSize)]
 pub struct ProcValue {
     pub location: Location,
     pub parameters: Box<[Parameter]>,
@@ -88,7 +95,7 @@ pub struct ProcValue {
     pub code: Option<Block>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, GetSize)]
 pub struct TypeProc {
     pub value: Vec<ProcValue>,
     pub declaration: Option<ProcDeclaration>,
@@ -187,6 +194,21 @@ impl Type {
             current = objtree.parent_of(ty);
         }
         None
+    }
+}
+
+impl GetSize for Type {
+    fn get_heap_size(&self) -> usize {
+        self.path.get_heap_size()
+        + self.path_last_slash.get_heap_size()
+        + self.location.get_heap_size()
+        + self.parent_path.get_heap_size()
+        + self.parent_type.get_heap_size()
+        + self.docs.get_heap_size()
+        + self.id.get_heap_size()
+        + self.children.get_heap_size()
+        + heap_size_of_index_map(&self.vars)
+        + heap_size_of_index_map(&self.procs)
     }
 }
 
@@ -624,7 +646,7 @@ impl<'a> std::hash::Hash for ProcRef<'a> {
 // ----------------------------------------------------------------------------
 // The object tree itself
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, GetSize)]
 pub struct ObjectTree {
     graph: Vec<Type>,
     types: BTreeMap<String, NodeIndex>,
@@ -1295,3 +1317,5 @@ impl NodeIndex {
         NodeIndex(std::u32::MAX)
     }
 }
+
+impl GetSize for NodeIndex{}

--- a/crates/dreammaker/src/objtree.rs
+++ b/crates/dreammaker/src/objtree.rs
@@ -23,7 +23,7 @@ use super::{DMError, Location, Context, Severity};
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct SymbolId(u32);
 
-impl GetSize for SymbolId{}
+impl GetSize for SymbolId {}
 
 #[derive(Debug)]
 pub struct SymbolIdSource(SymbolId);
@@ -111,15 +111,17 @@ impl TypeProc {
 // ----------------------------------------------------------------------------
 // Types
 
-#[derive(Debug)]
+#[derive(Debug, GetSize)]
 pub struct Type {
     pub path: String,
     path_last_slash: usize,
     pub location: Location,
     location_specificity: usize,
     /// Variables which this type has declarations or overrides for.
+    #[get_size(size_fn = heap_size_of_index_map)]
     pub vars: IndexMap<String, TypeVar, RandomState>,
     /// Procs and verbs which this type has declarations or overrides for.
+    #[get_size(size_fn = heap_size_of_index_map)]
     pub procs: IndexMap<String, TypeProc, RandomState>,
     parent_path: NodeIndex,
     parent_type: NodeIndex,
@@ -194,21 +196,6 @@ impl Type {
             current = objtree.parent_of(ty);
         }
         None
-    }
-}
-
-impl GetSize for Type {
-    fn get_heap_size(&self) -> usize {
-        self.path.get_heap_size()
-        + self.path_last_slash.get_heap_size()
-        + self.location.get_heap_size()
-        + self.parent_path.get_heap_size()
-        + self.parent_type.get_heap_size()
-        + self.docs.get_heap_size()
-        + self.id.get_heap_size()
-        + self.children.get_heap_size()
-        + heap_size_of_index_map(&self.vars)
-        + heap_size_of_index_map(&self.procs)
     }
 }
 
@@ -1318,4 +1305,4 @@ impl NodeIndex {
     }
 }
 
-impl GetSize for NodeIndex{}
+impl GetSize for NodeIndex {}


### PR DESCRIPTION
Useful for diagnostics.

(Draft since no Cargo.toml changes until upstream is accepted/published https://github.com/DKerp/get-size/pull/6. Alternatively, could target my git fork with `get-size = { git = "https://github.com/Cyberboss/get-size", branch = "MoreAdditions" }`)