### PR TITLE
Implements base functionality for __TYPE__ and __PROC__

### DIFF
--- a/crates/dm-langserver/src/find_references.rs
+++ b/crates/dm-langserver/src/find_references.rs
@@ -544,6 +544,20 @@ impl<'o> WalkProc<'o> {
                     StaticType::None
                 }
             },
+
+            Term::__TYPE__ => {
+                self.tab.use_symbol(self.ty.id, location);
+                StaticType::None
+            },
+            Term::__PROC__ => {
+                let Some(proc) = self.proc else {
+                    return StaticType::None
+                };
+                if let Some(decl) = self.ty.get_proc_declaration(proc.name()) {
+                    self.tab.use_symbol(decl.id, location);
+                }
+                StaticType::None
+            }
         }
     }
 

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -628,6 +628,10 @@ impl<'a, T: fmt::Display> fmt::Display for FormatTreePath<'a, T> {
 /// A series of identifiers separated by path operators.
 pub type TypePath = Vec<(PathOp, Ident)>;
 
+pub fn make_typepath(segments: Vec<String>) -> TypePath {
+    segments.into_iter().fold(vec![], |mut acc, segment| { acc.push((PathOp::Slash, segment)); acc })
+}
+
 pub struct FormatTypePath<'a>(pub &'a [(PathOp, Ident)]);
 
 impl<'a> fmt::Display for FormatTypePath<'a> {
@@ -852,6 +856,10 @@ pub enum Term {
     Resource(String),
     /// An `as()` call, with an input type. Undocumented.
     As(InputType),
+    /// A reference to our current proc's name
+    __PROC__,
+    /// A reference to the current proc/scope's type
+    __TYPE__,
 
     // Non-function calls with recursive contents -----------------------------
     /// An expression contained in a term.

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -769,6 +769,15 @@ impl<'a> ConstantFolder<'a> {
             Term::Int(v) => Constant::Float(v as f32),
             Term::Float(v) => Constant::from(v),
             Term::Expr(expr) => self.expr(*expr, type_hint)?,
+            Term::__TYPE__ => {
+                if let Some(obj_tree) = &self.tree {
+                    let typeval = TypeRef::new(obj_tree, self.ty).get();
+                    let path = make_typepath(typeval.path.split("/").filter(|elem| *elem != "").map(|segment| segment.to_string()).collect());
+                    Constant::Prefab(Box::new(self.prefab(Prefab::from(path))?))
+                } else {
+                    return Err(self.error("No type context".to_owned()))
+                }
+            },
             _ => return Err(self.error("non-constant expression".to_owned())),
         })
     }

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -2065,7 +2065,18 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 require!(self.exact(Token::Punct(Punctuation::RParen)));
                 Term::As(input_type)
             },
+            // term :: __PROC__
+            Token::Ident(ref i, _) if i == "__PROC__" => {
+                // We cannot replace with the proc path yet, you don't need one it's fine
+                Term::__PROC__
+                },
 
+            // term :: __TYPE__
+            Token::Ident(ref i, _) if i == "__TYPE__" => {
+                // We cannot replace with the typepath yet, so we'll hand back a term we can parse later
+                Term::__TYPE__
+            },
+            
             // term :: ident arglist | ident
             Token::Ident(i, _) => {
                 let first_token = self.updated_location();

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -2069,14 +2069,14 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             Token::Ident(ref i, _) if i == "__PROC__" => {
                 // We cannot replace with the proc path yet, you don't need one it's fine
                 Term::__PROC__
-                },
+            },
 
             // term :: __TYPE__
             Token::Ident(ref i, _) if i == "__TYPE__" => {
                 // We cannot replace with the typepath yet, so we'll hand back a term we can parse later
                 Term::__TYPE__
             },
-            
+
             // term :: ident arglist | ident
             Token::Ident(i, _) => {
                 let first_token = self.updated_location();


### PR DESCRIPTION
We basically just capture them early, and then treat them as unique symbols. We don't replace inline or anything because the required context isn't quite there.

I'm not really sure I have ctrl click functionality working. To be honest with you I'm not really sure how to hook into that system, pointers would be appreciated. I thought it was based off the use of use_symbol in find refs but that doesn't seem to work. 