### PR TITLE
Implements the scope operator

### DIFF
--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1992,8 +1992,41 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 }
             },
             Follow::StaticField(name) => {
-                // TODO
-                Analysis::empty()
+                let real_type = match lhs.static_ty.basic_type() {
+                    Some(existing_type) => existing_type,
+                    None => {
+                        let Some(to_our_side) = lhs.value else {
+                            error(location, format!("no typepath found for: {:?}", name))
+                                .register(self.context);
+                            return Analysis::empty()
+                        };
+                        let Constant::Prefab(typepop) = to_our_side else {
+                            error(location, format!("static access requires a static typepath, {} found instead", to_our_side))
+                                .register(self.context);
+                            return Analysis::empty()
+                        };
+                        if !&typepop.vars.is_empty() {
+                            error(location, format!("static access requires a static typepath, {} found instead", typepop))
+                                .register(self.context);
+                            return Analysis::empty()
+                        }
+                        let typepath = dm::ast::FormatTreePath(&typepop.path).to_string();
+                        let Some(found_type) = self.objtree.find(typepath.as_str()) else {
+                            error(location, format!("static access requires an existing typepath, {} found instead", typepath))
+                                .register(self.context);
+                            return Analysis::empty()
+                        };
+                        found_type
+                    }
+                };
+                let Some(decl) = real_type.get_var_declaration(name) else {
+                    error(location, format!("undefined field: {:?} on {}", name, real_type))
+                        .register(self.context);
+                    return Analysis::empty()
+                };
+
+                self.static_type(location, &decl.var_type.type_path)
+                    .with_fix_hint(decl.location, "add additional type info here")
             },
 
             Follow::Call(kind, name, arguments) => {
@@ -2033,8 +2066,54 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 }
             },
             Follow::ProcReference(name) => {
-                // TODO
-                Analysis::empty()
+                let real_type = match lhs.static_ty.basic_type() {
+                    Some(existing_type) => existing_type,
+                    None => {
+                        let Some(to_our_side) = lhs.value else {
+                            error(location, format!("no typepath found for: {:?}", name))
+                                .register(self.context);
+                            return Analysis::empty()
+                        };
+                        let Constant::Prefab(typepop) = to_our_side else {
+                            error(location, format!("static proc reference requires a static typepath, {} found instead", to_our_side))
+                                .register(self.context);
+                            return Analysis::empty()
+                        };
+                        if !&typepop.vars.is_empty() {
+                            error(location, format!("static proc reference requires a static typepath, {} found instead", typepop))
+                                .register(self.context);
+                            return Analysis::empty()
+                        }
+                        let typepath = dm::ast::FormatTreePath(&typepop.path).to_string();
+                        let Some(found_type) = self.objtree.find(typepath.as_str()) else {
+                            error(location, format!("static proc reference requires an existing typepath, {} found instead", typepath))
+                                .register(self.context);
+                            return Analysis::empty()
+                        };
+                        found_type
+                    }
+                };
+                let Some(decl) = real_type.get_proc(name) else {
+                    error(location, format!("undefined proc: {:?} on {}", name, real_type))
+                        .register(self.context);
+                    return Analysis::empty()
+                };
+
+                // Gonna build the proc's path
+                let mut path_elements: Vec<String> = real_type.get().path.split("/").filter(|elem| *elem != "").map(|segment| segment.to_string()).collect();
+                // Only tricky bit is adding on the type if required
+                if let Some(declaration) = decl.get_declaration() {
+                    path_elements.push(declaration.kind.name().to_string());
+                }
+                path_elements.push(decl.name().to_string());
+                let path_const = dm::constants::Pop::from(path_elements.into_boxed_slice());
+                Analysis {
+                    static_ty: StaticType::None,
+                    aset: assumption_set![Assumption::IsPath(true, real_type)],
+                    value: Some(Constant::Prefab(Box::new(path_const))),
+                    fix_hint: None,
+                    is_impure: None,
+                }
             },
         }
     }

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -268,6 +268,8 @@ pub enum PropertyAccessKind {
     SafeDot,
     /// `a?:b`
     SafeColon,
+    /// 'a::b'
+    Scope,
 }
 
 impl PropertyAccessKind {
@@ -277,6 +279,7 @@ impl PropertyAccessKind {
             PropertyAccessKind::Colon => ":",
             PropertyAccessKind::SafeDot => "?.",
             PropertyAccessKind::SafeColon => "?:",
+            PropertyAccessKind::Scope => "::",
         }
     }
 }
@@ -627,6 +630,10 @@ impl<'a, T: fmt::Display> fmt::Display for FormatTreePath<'a, T> {
 
 /// A series of identifiers separated by path operators.
 pub type TypePath = Vec<(PathOp, Ident)>;
+
+pub fn make_typepath(segments: Vec<String>) -> TypePath {
+    segments.into_iter().fold(vec![], |mut acc, segment| { acc.push((PathOp::Slash, segment)); acc })
+}
 
 pub struct FormatTypePath<'a>(pub &'a [(PathOp, Ident)]);
 

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -659,7 +659,7 @@ impl<'a> ConstantFolder<'a> {
                 let Some(real_type) = tree.find(FormatTreePath(&read_from.path).to_string().as_str()) else {
                     return Err(self.error(format!("{} was not a valid type", FormatTreePath(&read_from.path))))
                 };
-                self.recursive_lookup(real_type.index(), &field, true)
+                self.recursive_lookup(real_type.index(), &field, false)
             },
             (term, Follow::ProcReference(field)) => {
                 let Constant::Prefab(read_from) = term else {

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -646,6 +646,36 @@ impl<'a> ConstantFolder<'a> {
                 }
             }
             (term, Follow::Unary(op)) => self.unary(term, op),
+            (term, Follow::StaticField(field)) => {
+                let Constant::Prefab(read_from) = term else {
+                    return Err(self.error(format!("non typepath {} used with ::", term)))
+                };
+                if read_from.vars.len() > 0 {
+                    return Err(self.error(format!("non typepath {} used with ::", read_from)))
+                }
+                let Some(ref tree) = self.tree else {
+                    return Err(self.error("no type tree available"))
+                };
+                let Some(real_type) = tree.find(FormatTreePath(&read_from.path).to_string().as_str()) else {
+                    return Err(self.error(format!("{} was not a valid type", FormatTreePath(&read_from.path))))
+                };
+                self.recursive_lookup(real_type.index(), &field, true)
+            },
+            (term, Follow::ProcReference(field)) => {
+                let Constant::Prefab(read_from) = term else {
+                    return Err(self.error(format!("non typepath {} used with ::", term)))
+                };
+                if read_from.vars.len() > 0 {
+                    return Err(self.error(format!("non typepath {} used with ::", read_from)))
+                }
+                let Some(ref tree) = self.tree else {
+                    return Err(self.error("no type tree available"))
+                };
+                let Some(real_type) = tree.find(FormatTreePath(&read_from.path).to_string().as_str()) else {
+                    return Err(self.error(format!("{} was not a valid type", FormatTreePath(&read_from.path))))
+                };
+                self.proc_ref_lookup(real_type.index(), &field)
+            },
             (term, follow) => Err(self.error(format!("non-constant expression follower: {} {:?}", term, follow))),
         }
     }
@@ -763,7 +793,33 @@ impl<'a> ConstantFolder<'a> {
                 _ => return Err(self.error(format!("non-constant function call: {}", ident))),
             },
             Term::Prefab(prefab) => Constant::Prefab(Box::new(self.prefab(*prefab)?)),
-            Term::Ident(ident) => self.ident(ident, false)?,
+            Term::Ident(ident) => match ident.as_str() {
+                // We need to handle type and parent_type here
+                // They technically resolve to their respective values only in type defs when using ::
+                // But that's annoying so let's not
+                "type" => {
+                    if let Some(obj_tree) = &self.tree {
+                        let typeval = TypeRef::new(obj_tree, self.ty).get();
+                        let path = make_typepath(typeval.path.split("/").filter(|elem| *elem != "").map(|segment| segment.to_string()).collect());
+                        Constant::Prefab(Box::new(self.prefab(Prefab::from(path))?))
+                    } else {
+                        return Err(self.error("no type context".to_owned()))
+                    }
+                },
+                "parent_type" => {
+                    if let Some(obj_tree) = &self.tree {
+                        let typeref = TypeRef::new(obj_tree, self.ty);
+                        let Some(parent_type) = typeref.parent_type() else {
+                            return Err(self.error(format!("no parent type for {}", typeref)))
+                        };
+                        let path = make_typepath(parent_type.path.split("/").filter(|elem| *elem != "").map(|segment| segment.to_string()).collect());
+                        Constant::Prefab(Box::new(self.prefab(Prefab::from(path))?))
+                    } else {
+                        return Err(self.error("no type context".to_owned()))
+                    }
+                }
+                _ => self.ident(ident, false)?,
+            },
             Term::String(v) => Constant::String(v.into()),
             Term::Resource(v) => Constant::Resource(v.into()),
             Term::Int(v) => Constant::Float(v as f32),
@@ -843,6 +899,22 @@ impl<'a> ConstantFolder<'a> {
             }
         }
         Err(self.error(format!("unknown variable: {}", ident)))
+    }
+
+    fn proc_ref_lookup(&mut self, ty: NodeIndex, name: &str) -> Result<Constant, DMError> {
+        let tree = self.tree.as_mut().unwrap();
+        let proc_type = TypeRef::new(tree, ty);
+        let Some(proc_ref) = proc_type.get_proc(name) else {
+            return Err(self.error(format!("unknown proc: {}", name)))
+        };
+        // Gonna build the proc's path
+        let mut path_elements: Vec<String> = proc_type.get().path.split("/").filter(|elem| *elem != "").map(|segment| segment.to_string()).collect();
+        // Only tricky bit is adding on the type if required
+        if let Some(declaration) = proc_ref.get_declaration() {
+            path_elements.push(declaration.kind.name().to_string());
+        }
+        path_elements.push(proc_ref.name().to_string());
+        Ok(Constant::Prefab(Box::new(self.prefab(Prefab::from(make_typepath(path_elements)))?)))
     }
 
     fn rgb(&mut self, args: Box<[Expression]>) -> Result<String, DMError> {

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -2108,6 +2108,18 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                     Term::Ident(".".to_owned())
                 }
             },
+            Token::Punct(Punctuation::Scope) => {
+                if let Some(ident) = self.ident()? {
+                    if let Some(args) = self.arguments(&[], "::")? {
+                        Term::GlobalCall(Ident2::from(ident), args)
+                    } else {
+                        Term::GlobalIdent(Ident2::from(ident))
+                    }
+                } else {
+                    // Go away
+                    return self.parse_error()
+                }
+            }
             // term :: path_lit
             t @ Token::Punct(Punctuation::Slash) |
             t @ Token::Punct(Punctuation::CloseColon) => {
@@ -2191,6 +2203,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             Token::Punct(Punctuation::CloseColon) if !belongs_to.is_empty() || !in_ternary => PropertyAccessKind::Colon,
             Token::Punct(Punctuation::SafeDot) => PropertyAccessKind::SafeDot,
             Token::Punct(Punctuation::SafeColon) => PropertyAccessKind::SafeColon,
+            Token::Punct(Punctuation::Scope) => PropertyAccessKind::Scope,
 
             other => return self.try_another(other),
         };
@@ -2217,14 +2230,28 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                     let past = std::mem::take(belongs_to);
                     self.annotate_precise(start..end, || Annotation::ScopedCall(past, ident.clone()));
                 }
-                Follow::Call(kind, ident.into(), args)
+                match kind {
+                    PropertyAccessKind::Scope => {
+                        Follow::ProcReference(ident.into())
+                    }
+                    _ => {
+                        Follow::Call(kind, ident.into(), args)
+                    }
+                }
             },
             None => {
                 if !belongs_to.is_empty() {
                     self.annotate_precise(start..end, || Annotation::ScopedVar(belongs_to.clone(), ident.clone()));
                     belongs_to.push(ident.clone());
                 }
-                Follow::Field(kind, ident.into())
+                match kind {
+                    PropertyAccessKind::Scope => {
+                        Follow::StaticField(ident.into())
+                    }
+                    _ => {
+                        Follow::Field(kind, ident.into())
+                    }
+                }
             },
         };
         success(Spanned::new(first_location, follow))

--- a/crates/dreammaker/tests/ast_tests.rs
+++ b/crates/dreammaker/tests/ast_tests.rs
@@ -1,6 +1,10 @@
 extern crate dreammaker as dm;
 
+use core::panic;
+
 use dm::*;
+use dm::constants::*;
+use dm::ast::*;
 use dm::preprocessor::Preprocessor;
 use dm::objtree::ObjectTree;
 
@@ -15,6 +19,7 @@ fn with_code<F: FnOnce(Context, ObjectTree)>(code: &'static str, f: F) {
 
     f(context, _tree)
 }
+
 
 #[test]
 fn check_semicolon_in_proc_parameters() {
@@ -31,4 +36,199 @@ fn check_semicolon_in_proc_parameters() {
             assert_eq!(error.errortype().expect("No errortype set!"), "semicolon_in_proc_parameter");
         }
     });
+}
+
+#[test]
+fn process_scope() {
+    with_code("
+/datum/test
+    var/base = 10
+    var/heck = type::base
+    var/static/stat = 1
+    var/proc_holder = type::reference()
+
+/datum/test/proc/reference()
+
+/datum/test/sub
+    base = parent_type::base + 10
+    heck = /datum/test::heck + 2
+
+var/global/bill = 1
+
+/proc/work()
+    var/x = /datum/test::base
+    var/datum/test/larry = /datum/test
+    x = larry::stat
+    x = /datum/test::reference()
+    /datum/test::stat = 2
+    ::extra()
+    x = ::bill
+
+/proc/extra()
+", |context, tree| {
+        let errors = context.errors();
+
+        // Check for errors
+        for error in errors.iter() {
+            panic!("{}", error);
+        }
+        // test type::var in typedef
+        let parent_type = tree.find("/datum/test").unwrap();
+        let type_read = parent_type.get_value("heck").unwrap();
+        let Some(constant) = type_read.constant.as_ref() else {
+            panic!("Failed to constant evaluate :: operator")
+        };
+        if let Constant::Float(value) = constant {
+            assert_eq!(*value, 10f32)
+        } else {
+            panic!("{} was expected to be a float, but it wasn't!", type_read.constant.as_ref().unwrap())
+        }
+        // test type::proc() in typedef
+        let parent_type = tree.find("/datum/test").unwrap();
+        let type_read = parent_type.get_value("proc_holder").unwrap();
+        let Some(constant) = type_read.constant.as_ref() else {
+            panic!("Failed to constant evaluate :: proc operator")
+        };
+        if let Constant::Prefab(value) = constant {
+            let pop_list = FormatTreePath(&value.path).to_string();
+            assert_eq!(pop_list, "/datum/test/proc/reference")
+        } else {
+            panic!("{} was expected to be a path, but it wasn't!", type_read.constant.as_ref().unwrap())
+        }
+        //  parent_type::var in a subtype
+        let child_type = tree.find("/datum/test/sub").unwrap();
+        let type_read = child_type.get_value("base").unwrap();
+        let Some(constant) = type_read.constant.as_ref() else {
+            panic!("Failed to constant evaluate :: operator")
+        };
+        if let Constant::Float(value) = constant {
+            assert_eq!(*value, 10f32 + 10f32)
+        } else {
+            panic!("{} was expected to be a float, but it wasn't!", type_read.constant.as_ref().unwrap())
+        }
+        // /datum/explicit::var in a type
+        let child_type = tree.find("/datum/test/sub").unwrap();
+        let type_read = child_type.get_value("heck").unwrap();
+        let Some(constant) = type_read.constant.as_ref() else {
+            panic!("Failed to constant evaluate :: operator")
+        };
+        if let Constant::Float(value) = constant {
+            assert_eq!(*value, 10f32 + 2f32)
+        } else {
+            panic!("{} was expected to be a float, but it wasn't!", type_read.constant.as_ref().unwrap())
+        }
+        let global_procs = tree.root();
+        let work_proc = global_procs.get_proc("work").unwrap();
+        let work_code = work_proc.code.as_ref().unwrap().into_iter().map(|statement| {
+            &statement.elem
+        }).collect::<Vec<&Statement>>();
+        // /datum/explicit::var
+        let Statement::Var(x_init) = work_code.first().unwrap() else {
+            panic!("First statement was not an expression")
+        };
+        let Expression::Base { term: _, follow } = x_init.value.as_ref().unwrap() else {
+            panic!("/datum/test::base was NOT evaluated as a base expression")
+        };
+        match &follow.first().unwrap().elem {
+            Follow::StaticField(field) => {
+                if field != "base" {
+                    panic!("/datum/test::base did not eval base as the var to read")
+                }
+            }
+            _ => panic!("/datum/test::base failed to eval :: as a static field")
+        }
+        // implicit_type::variable
+        let Statement::Expr(larrys_read) = work_code.get(2).unwrap() else {
+            panic!("Third statement was not an expression")
+        };
+
+        let Expression::AssignOp { op: _, lhs: _, rhs } = larrys_read else {
+            panic!("x = larry::stat was NOT evaluated as an assignment expression")
+        };
+        let Expression::Base { term: _, ref follow } = **rhs else {
+            panic!("larry::stat was NOT evaluated as a base expression")
+        };
+        match &follow.first().unwrap().elem {
+            Follow::StaticField(field) => {
+                if field != "stat" {
+                    panic!("larry::stat did not eval stat as the var to read")
+                }
+            }
+            _ => panic!("larry::stat failed to eval :: as a static field")
+        }
+
+        // /datum/explicit::proc()
+        let Statement::Expr(proc_ref) = work_code.get(3).unwrap() else {
+            panic!("Fourth statement was not an expression")
+        };
+
+        let Expression::AssignOp { op: _, lhs: _, rhs } = proc_ref else {
+            panic!("x = /datum/test::reference() was NOT evaluated as an assignment expression")
+        };
+        let Expression::Base { term: _, ref follow } = **rhs else {
+            panic!("/datum/test::reference() was NOT evaluated as a base expression")
+        };
+        match &follow.first().unwrap().elem {
+            Follow::ProcReference(proc_name) => {
+                if proc_name != "reference" {
+                    panic!("/datum/test::reference() did not eval reference() as the ref to read")
+                }
+            }
+            _ => panic!("/datum/test::reference() failed to eval :: as a proc reference")
+        }
+        // /datum/explicit::static_var = value
+        let Statement::Expr(static_set) = work_code.get(4).unwrap() else {
+            panic!("Fifth statement was not an expression")
+        };
+
+        let Expression::AssignOp { op: _, lhs, rhs: _ } = static_set else {
+            panic!("/datum/test::stat = 2 was NOT evaluated as an assignment expression")
+        };
+        let Expression::Base { term: _, ref follow } = **lhs else {
+            panic!("/datum/test::stat was NOT evaluated as a base expression")
+        };
+        match &follow.first().unwrap().elem {
+            Follow::StaticField(field) => {
+                if field != "stat" {
+                    panic!("/datum/test::stat did not eval stat as the var to set")
+                }
+            }
+            _ => panic!("/datum/test::stat failed to eval :: as a static field")
+        }
+        // ::global_proc()
+        let Statement::Expr(static_set) = work_code.get(5).unwrap() else {
+            panic!("Sixth statement was not an expression")
+        };
+
+        let Expression::Base { term, follow: _ } = static_set else {
+            panic!("::extra() was NOT evaluated as a base expression")
+        };
+        match &term.elem {
+            Term::GlobalCall(function, _) => {
+                if function != "extra" {
+                    panic!("::extra() did not eval extra as the proc to call")
+                }
+            }
+            _ => panic!("::extra() failed to eval :: as a global call")
+        }
+        // ::global_var
+        let Statement::Expr(proc_ref) = work_code.get(6).unwrap() else {
+            panic!("Seventh statement was not an expression")
+        };
+
+        let Expression::AssignOp { op: _, lhs: _, rhs } = proc_ref else {
+            panic!("x = ::bill was NOT evaluated as an assignment expression")
+        };
+        let Expression::Base { ref term, follow: _ } = **rhs else {
+            panic!("::bill was NOT evaluated as a base expression")
+        };
+        match &term.elem {
+            Term::GlobalIdent(field) => {
+                if field != "bill" {
+                    panic!("::bill did not eval bill as the global var to read")
+                }
+            }
+            _ => panic!("::bill failed to eval :: as a global var read")
+        }
+    })
 }

--- a/crates/dreammaker/tests/ast_tests.rs
+++ b/crates/dreammaker/tests/ast_tests.rs
@@ -42,6 +42,7 @@ fn check_semicolon_in_proc_parameters() {
 fn process_scope() {
     with_code("
 /datum/test
+    var/hell = type::base
     var/base = 10
     var/heck = type::base
     var/static/stat = 1
@@ -69,8 +70,12 @@ var/global/bill = 1
         let errors = context.errors();
 
         // Check for errors
+        let mut sum_errors: Vec<String> = vec![];
         for error in errors.iter() {
-            panic!("{}", error);
+            sum_errors.push(format!("{}", error));
+        }
+        if sum_errors.len() > 0 {
+            panic!("\n{}", sum_errors.join("\n").as_str());
         }
         // test type::var in typedef
         let parent_type = tree.find("/datum/test").unwrap();


### PR DESCRIPTION
Adds support for :: to the parser, in all its forms (global proc/var, off type)
Also implements behavior for it. We'll properly read the type of what we attach to, and double check that everything matches. Works for the proc refs too.

I've added unit tests for all this to double check my work. I DIDN'T mirror the static var detection byond does. problem for another day.

Please let me know if the way I'm going about this is silly/mislead, I'll declutter as directed