### PR TITLE
dmm_tools::dmm::save_tgm to take &mut impl Write

### DIFF
--- a/crates/dmm-tools/src/dmm.rs
+++ b/crates/dmm-tools/src/dmm.rs
@@ -181,9 +181,12 @@ impl Map {
         Ok(map)
     }
 
+    pub fn to_writer(&self, writer: &mut impl std::io::Write) -> io::Result<()> {
+        save_tgm::save_tgm(self, writer)
+    }
+
     pub fn to_file(&self, path: &Path) -> io::Result<()> {
-        // DMM saver later
-        save_tgm::save_tgm(self, File::create(path)?)
+        self.to_writer(&mut File::create(path)?)
     }
 
     pub fn key_length(&self) -> u8 {

--- a/crates/dmm-tools/src/dmm/save_tgm.rs
+++ b/crates/dmm-tools/src/dmm/save_tgm.rs
@@ -1,5 +1,4 @@
 //! TGM map writer.
-use std::fs::File;
 use std::io::{self, Write, BufWriter};
 
 use ndarray::Axis;
@@ -10,8 +9,8 @@ const TGM_HEADER: &str = "//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREV
 
 // Note: writeln! currently (2022-04-30) writes the \n character alone on all platforms
 // If that changes, this will break.
-pub fn save_tgm(map: &Map, f: File) -> io::Result<()> {
-    let mut f = BufWriter::new(f);
+pub fn save_tgm(map: &Map, w: &mut impl Write) -> io::Result<()> {
+    let mut f = BufWriter::new(w);
     writeln!(f, "{}", TGM_HEADER)?;
 
     // dictionary


### PR DESCRIPTION
Also `dmm_tools::dmm::Map::to_writer()`, so it can be used to save to a string and not just a file, for use in external tooling that depends on this, and may want to, for example, pass the string back to byond from rust-g.

`dmm_tools::dmm::Map::to_string()` is kept for convenience (and backwards compatibility I guess to not break code), but it just uses the `::to_writer()` function.