### PR TITLE
dmm_tools::dmm::Map::adjust_key_length() fix

### DIFF
--- a/crates/dmm-tools/src/dmm.rs
+++ b/crates/dmm-tools/src/dmm.rs
@@ -191,12 +191,15 @@ impl Map {
     }
 
     pub fn adjust_key_length(&mut self) {
-        if self.dictionary.len() > 2704 {
-            self.key_length = 3;
-        } else if self.dictionary.len() > 52 {
-            self.key_length = 2;
-        } else {
-            self.key_length = 1;
+        if let Some(max_key) = self.dictionary.keys().max() {
+            let max_key = max_key.0;
+            if max_key > 2704 {
+                self.key_length = 3;
+            } else if max_key > 52 {
+                self.key_length = 2;
+            } else {
+                self.key_length = 1;
+            }
         }
     }
 

--- a/crates/dmm-tools/src/dmm.rs
+++ b/crates/dmm-tools/src/dmm.rs
@@ -200,6 +200,10 @@ impl Map {
         }
     }
 
+    pub fn set_key_length(&mut self, key_length: u8) {
+        self.key_length = key_length;
+    }
+
     #[inline]
     pub fn dim_xyz(&self) -> (usize, usize, usize) {
         let dim = self.grid.dim();

--- a/crates/dmm-tools/src/dmm.rs
+++ b/crates/dmm-tools/src/dmm.rs
@@ -203,10 +203,6 @@ impl Map {
         }
     }
 
-    pub fn set_key_length(&mut self, key_length: u8) {
-        self.key_length = key_length;
-    }
-
     #[inline]
     pub fn dim_xyz(&self) -> (usize, usize, usize) {
         let dim = self.grid.dim();

--- a/crates/dmm-tools/src/dmm.rs
+++ b/crates/dmm-tools/src/dmm.rs
@@ -196,9 +196,9 @@ impl Map {
     pub fn adjust_key_length(&mut self) {
         if let Some(max_key) = self.dictionary.keys().max() {
             let max_key = max_key.0;
-            if max_key > 2704 {
+            if max_key >= 2704 {
                 self.key_length = 3;
-            } else if max_key > 52 {
+            } else if max_key >= 52 {
                 self.key_length = 2;
             } else {
                 self.key_length = 1;


### PR DESCRIPTION
Currently, there is `Map::adjust_key_length()`, but it sets key length based on the amount of items in the dictionary. Which is fine if keys in order like 1-2-3-4-...-N, but it falls apart if the keys are not in order - which is valid for a dmm map.

If a map has keys like [1, 2, 3000], then, currently, `Map::adjust_key_length()` will set key length to 1, but the map will panic on save cause the 3000 key is bigger than max key for this key length (52).

This PR fixes `adjust_key_length` to work properly in that case, where it sets key length based on the biggest key in the map dictionary.