### PR TITLE
fexists can be called in the preprocessor

### DIFF
--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -143,6 +143,7 @@ impl<'o> AssumptionSet<'o> {
                 ConstFn::Newlist => AssumptionSet::from_valid_instance(objtree.expect("/list")),
                 ConstFn::Sound => AssumptionSet::from_valid_instance(objtree.expect("/sound")),
                 ConstFn::Generator => AssumptionSet::from_valid_instance(objtree.expect("/generator")),
+                ConstFn::FileExists => AssumptionSet::default(),
                 ConstFn::Filter => AssumptionSet::default(),
                 ConstFn::File => AssumptionSet::default(),
             },

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -815,11 +815,14 @@ impl<'a> ConstantFolder<'a> {
                         None => return Err(self.error("malformed nameof() call, expression appears to have no name")),
                     }
                 }
-                "fexists" => {
+                "fexists" if self.defines.is_some() => {
                     if args.len() != 1 {
                         return Err(self.error(format!("malformed fexists() call, must have 1 argument and instead has {}", args.len())));
                     }
-                    Constant::Call(ConstFn::FileExists, self.arguments(args)?)
+                    match args[0].as_term() {
+                        Some(Term::String(ref path)) => Constant::from(std::path::Path::new(path).exists()),
+                        _ => return Err(self.error("malformed fexists() call, argument given isn't a string.")),
+                    }
                 }
                 // other functions are no-goes
                 _ => return Err(self.error(format!("non-constant function call: {}", ident))),

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -154,6 +154,8 @@ pub enum ConstFn {
     File,
     /// The `generator()` type constructor.
     Generator,
+    /// `fexists()`, which can be used in preprocessor expressions.
+    FileExists,
 }
 
 /// A constant-evaluation error (usually type mismatch).
@@ -411,6 +413,7 @@ impl fmt::Display for ConstFn {
             ConstFn::Filter => "filter",
             ConstFn::File => "file",
             ConstFn::Generator => "generator",
+            ConstFn::FileExists => "fexists"
         })
     }
 }
@@ -811,6 +814,12 @@ impl<'a> ConstantFolder<'a> {
                         Some(name) => Constant::string(name),
                         None => return Err(self.error("malformed nameof() call, expression appears to have no name")),
                     }
+                }
+                "fexists" => {
+                    if args.len() != 1 {
+                        return Err(self.error(format!("malformed fexists() call, must have 1 argument and instead has {}", args.len())));
+                    }
+                    Constant::Call(ConstFn::FileExists, self.arguments(args)?)
                 }
                 // other functions are no-goes
                 _ => return Err(self.error(format!("non-constant function call: {}", ident))),

--- a/crates/dreammaker/tests/constants_tests.rs
+++ b/crates/dreammaker/tests/constants_tests.rs
@@ -112,9 +112,9 @@ fn rgb_hcy() {
 }
 
 #[test]
-fn fexists_noarg() {
+fn no_fexists_outside_preproc() {
     assert_eq!(
         eval("fexists()").unwrap_err().description(),
-        "malformed fexists() call, must have 1 argument and instead has 0",
+        "non-constant function call: fexists",
     );
 }

--- a/crates/dreammaker/tests/constants_tests.rs
+++ b/crates/dreammaker/tests/constants_tests.rs
@@ -110,3 +110,11 @@ fn rgb_hcy() {
         Constant::string("#000000"),
     );
 }
+
+#[test]
+fn fexists_noarg() {
+    assert_eq!(
+        eval("fexists()").unwrap_err().description(),
+        "malformed fexists() call, must have 1 argument and instead has 0",
+    );
+}

--- a/crates/dreammaker/tests/macro_tests.rs
+++ b/crates/dreammaker/tests/macro_tests.rs
@@ -69,3 +69,20 @@ ok2
         Ident("ok2".into(), false),
     ]);
 }
+
+#[test]
+fn fexists_function() {
+    assert_eq!(process(r#"
+#if fexists("README.md")
+exists
+#endif
+"#), &[
+        Ident("exists".into(), false),
+    ]);
+
+    assert_eq!(process(r#"
+#if fexists("this file does not exist")
+exists
+#endif
+"#), &[]);
+}


### PR DESCRIPTION
title, 515 feature https://www.byond.com/forum/post/2857912

currently, 
![image](https://github.com/SpaceManiac/SpacemanDMM/assets/4741640/f2cda4fc-837d-4f33-bc7b-c217fadcebb1)

can't actually const eval since it can have diff. behavior at runtime obv