### PR TITLE
Parses filter() properly

### DIFF
--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -785,6 +785,7 @@ impl<'a> ConstantFolder<'a> {
                 "newlist" => Constant::Call(ConstFn::Newlist, self.arguments(args)?),
                 "icon" => Constant::Call(ConstFn::Icon, self.arguments(args)?),
                 "sound" => Constant::Call(ConstFn::Sound, self.arguments(args)?),
+                "filter" => Constant::Call(ConstFn::Filter, self.arguments(args)?),
                 "file" => Constant::Call(ConstFn::File, self.arguments(args)?),
                 "generator" => Constant::Call(ConstFn::Generator, self.arguments(args)?),
                 // constant-evaluatable functions


### PR DESCRIPTION
We have a constant for it but nothing actually generates that constant. 
Should fix that.