### PR TITLE
changes the typepath in the gravitygenerator pass for dmm-tools-cli

### DIFF
--- a/crates/dmm-tools/src/render_passes/structures.rs
+++ b/crates/dmm-tools/src/render_passes/structures.rs
@@ -43,7 +43,7 @@ impl RenderPass for GravityGen {
         overlays: &mut Vec<Sprite<'a>>,
         _: &bumpalo::Bump,
     ) {
-        if !atom.istype("/obj/machinery/gravity_generator/main/station/") {
+        if !atom.istype("/obj/machinery/gravity_generator/main/") {
             return;
         }
 


### PR DESCRIPTION
/tg/ gravity generators no longer have a /station subtype so the gravity generator pass doesnt do anything
ideally this should be able to be configured (idk how to do rust stuff)