### PR TITLE
Changes severity of the `redefined proc` to Warning

### DIFF
--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1197,7 +1197,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 error(self.proc_ref.location, format!("redefining proc {}/{}", self.ty, self.proc_ref.name()))
                     .with_errortype("redefined_proc")
                     .with_note(parent.location, "previous definition is here")
-                    .set_severity(Severity::Hint)
+                    .set_severity(Severity::Warning)
                     .register(self.context);
             }
         }


### PR DESCRIPTION
These can be a lot of trouble and should be a lot more visible to fix
This will almost certainly create a lot of warnings on many codebases, not sure if I can/should do something for that?