### PR TITLE
fix preprocessor relative filepath evaluation for fexists

### DIFF
--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -2,6 +2,7 @@
 use std::fmt;
 use std::ops;
 use std::path::Path;
+use std::path::PathBuf;
 
 use get_size::GetSize;
 use get_size_derive::GetSize;
@@ -435,6 +436,7 @@ impl Expression {
     /// Evaluate this expression in the absence of any surrounding context.
     pub fn simple_evaluate(self, location: Location) -> Result<Constant, DMError> {
         ConstantFolder {
+            env_file: None,
             tree: None,
             location,
             ty: NodeIndex::new(0),
@@ -444,8 +446,9 @@ impl Expression {
 }
 
 /// Evaluate an expression in the preprocessor, with `defined()` available.
-pub fn preprocessor_evaluate(location: Location, expr: Expression, defines: &DefineMap) -> Result<Constant, DMError> {
+pub fn preprocessor_evaluate(location: Location, expr: Expression, defines: &DefineMap, env_file: Option<&PathBuf>) -> Result<Constant, DMError> {
     ConstantFolder {
+        env_file,
         tree: None,
         location,
         ty: NodeIndex::new(0),
@@ -466,7 +469,7 @@ pub(crate) fn evaluate_all(context: &Context, tree: &mut ObjectTree) {
             {
                 continue;  // skip non-constant-evaluable vars
             }
-            match constant_ident_lookup(tree, ty, &key, false) {
+            match constant_ident_lookup(tree, ty, &key, false, None) {
                 Err(err) => context.register_error(err),
                 Ok(ConstLookup::Found(_)) => {}
                 Ok(ConstLookup::Continue(_)) => {
@@ -494,6 +497,7 @@ fn constant_ident_lookup(
     ty: NodeIndex,
     ident: &str,
     must_be_const: bool,
+    env_file: Option<&PathBuf>,
 ) -> Result<ConstLookup, DMError> {
     // try to read the currently-set value if we can and
     // substitute that in, otherwise try to evaluate it.
@@ -544,6 +548,7 @@ fn constant_ident_lookup(
     };
     // evaluate full_value
     let value = ConstantFolder {
+        env_file,
         tree: Some(tree),
         defines: None,
         location,
@@ -557,6 +562,7 @@ fn constant_ident_lookup(
 }
 
 struct ConstantFolder<'a> {
+    env_file: Option<&'a PathBuf>,
     tree: Option<&'a mut ObjectTree>,
     defines: Option<&'a DefineMap>,
     location: Location,
@@ -818,7 +824,14 @@ impl<'a> ConstantFolder<'a> {
                         return Err(self.error(format!("malformed fexists() call, must have 1 argument and instead has {}", args.len())));
                     }
                     match args[0].as_term() {
-                        Some(Term::String(ref path)) => Constant::from(std::path::Path::new(path).exists()),
+                        Some(Term::String(ref path)) => {
+                            let full_path = self.env_file
+                                .as_ref()
+                                .and_then(|env_filepath| env_filepath.parent())
+                                .map(|parent| parent.join(path))
+                                .unwrap_or_else(|| std::path::PathBuf::from(path));
+                            Constant::from(full_path.exists())
+                        },
                         _ => return Err(self.error("malformed fexists() call, argument given isn't a string.")),
                     }
                 }
@@ -940,7 +953,7 @@ impl<'a> ConstantFolder<'a> {
                 return Err(self.error(format!("cannot reference variable {:?} in this context", ident)));
             }
             let tree = self.tree.as_mut().unwrap();
-            match constant_ident_lookup(tree, ty, ident, must_be_const)
+            match constant_ident_lookup( tree, ty, ident, must_be_const, self.env_file)
                 .map_err(|e| e.with_location(location))?
             {
                 ConstLookup::Found(v) => return Ok(v),

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -827,7 +827,7 @@ impl<'a> ConstantFolder<'a> {
                         Some(Term::String(passed_path)) => {
                             let current_file = self.location().file;
                             let path = self.context
-                                .map(|ctx| ctx.file_path(current_file).join(passed_path))
+                                .map(|ctx| ctx.file_path(current_file).parent().unwrap().join(passed_path))
                                 .unwrap_or_else(|| PathBuf::from(passed_path));
                             Constant::from(path.exists())
                         },

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -469,7 +469,7 @@ pub(crate) fn evaluate_all(context: &Context, tree: &mut ObjectTree) {
             {
                 continue;  // skip non-constant-evaluable vars
             }
-            match constant_ident_lookup(tree, ty, &key, false, None) {
+            match constant_ident_lookup(tree, ty, &key, false, context.config().environment.as_ref()) {
                 Err(err) => context.register_error(err),
                 Ok(ConstLookup::Found(_)) => {}
                 Ok(ConstLookup::Continue(_)) => {
@@ -953,7 +953,7 @@ impl<'a> ConstantFolder<'a> {
                 return Err(self.error(format!("cannot reference variable {:?} in this context", ident)));
             }
             let tree = self.tree.as_mut().unwrap();
-            match constant_ident_lookup( tree, ty, ident, must_be_const, self.env_file)
+            match constant_ident_lookup(tree, ty, ident, must_be_const, self.env_file)
                 .map_err(|e| e.with_location(location))?
             {
                 ConstLookup::Found(v) => return Ok(v),

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -436,7 +436,7 @@ impl Expression {
     /// Evaluate this expression in the absence of any surrounding context.
     pub fn simple_evaluate(self, location: Location) -> Result<Constant, DMError> {
         ConstantFolder {
-            env_file: None,
+            context: None,
             tree: None,
             location,
             ty: NodeIndex::new(0),
@@ -446,9 +446,9 @@ impl Expression {
 }
 
 /// Evaluate an expression in the preprocessor, with `defined()` available.
-pub fn preprocessor_evaluate(location: Location, expr: Expression, defines: &DefineMap, env_file: Option<&PathBuf>) -> Result<Constant, DMError> {
+pub fn preprocessor_evaluate(location: Location, expr: Expression, defines: &DefineMap, context: Option<&Context>) -> Result<Constant, DMError> {
     ConstantFolder {
-        env_file,
+        context,
         tree: None,
         location,
         ty: NodeIndex::new(0),
@@ -469,7 +469,7 @@ pub(crate) fn evaluate_all(context: &Context, tree: &mut ObjectTree) {
             {
                 continue;  // skip non-constant-evaluable vars
             }
-            match constant_ident_lookup(tree, ty, &key, false, context.config().environment.as_ref()) {
+            match constant_ident_lookup(tree, ty, &key, false, Some(context)) {
                 Err(err) => context.register_error(err),
                 Ok(ConstLookup::Found(_)) => {}
                 Ok(ConstLookup::Continue(_)) => {
@@ -497,7 +497,7 @@ fn constant_ident_lookup(
     ty: NodeIndex,
     ident: &str,
     must_be_const: bool,
-    env_file: Option<&PathBuf>,
+    context: Option<&Context>,
 ) -> Result<ConstLookup, DMError> {
     // try to read the currently-set value if we can and
     // substitute that in, otherwise try to evaluate it.
@@ -548,7 +548,7 @@ fn constant_ident_lookup(
     };
     // evaluate full_value
     let value = ConstantFolder {
-        env_file,
+        context,
         tree: Some(tree),
         defines: None,
         location,
@@ -562,7 +562,7 @@ fn constant_ident_lookup(
 }
 
 struct ConstantFolder<'a> {
-    env_file: Option<&'a PathBuf>,
+    context: Option<&'a Context>,
     tree: Option<&'a mut ObjectTree>,
     defines: Option<&'a DefineMap>,
     location: Location,
@@ -824,13 +824,12 @@ impl<'a> ConstantFolder<'a> {
                         return Err(self.error(format!("malformed fexists() call, must have 1 argument and instead has {}", args.len())));
                     }
                     match args[0].as_term() {
-                        Some(Term::String(ref path)) => {
-                            let full_path = self.env_file
-                                .as_ref()
-                                .and_then(|env_filepath| env_filepath.parent())
-                                .map(|parent| parent.join(path))
-                                .unwrap_or_else(|| std::path::PathBuf::from(path));
-                            Constant::from(full_path.exists())
+                        Some(Term::String(passed_path)) => {
+                            let current_file = self.location().file;
+                            let path = self.context
+                                .map(|ctx| ctx.file_path(current_file).join(passed_path))
+                                .unwrap_or_else(|| PathBuf::from(passed_path));
+                            Constant::from(path.exists())
                         },
                         _ => return Err(self.error("malformed fexists() call, argument given isn't a string.")),
                     }
@@ -953,7 +952,7 @@ impl<'a> ConstantFolder<'a> {
                 return Err(self.error(format!("cannot reference variable {:?} in this context", ident)));
             }
             let tree = self.tree.as_mut().unwrap();
-            match constant_ident_lookup(tree, ty, ident, must_be_const, self.env_file)
+            match constant_ident_lookup(tree, ty, ident, must_be_const, self.context)
                 .map_err(|e| e.with_location(location))?
             {
                 ConstLookup::Found(v) => return Ok(v),

--- a/crates/dreammaker/src/preprocessor.rs
+++ b/crates/dreammaker/src/preprocessor.rs
@@ -616,7 +616,7 @@ impl<'ctx> Preprocessor<'ctx> {
             start,
             self.output.drain(..),
         )?;
-        Ok(crate::constants::preprocessor_evaluate(start, expr, &self.defines, Some(&self.env_file))?.to_bool())
+        Ok(crate::constants::preprocessor_evaluate(start, expr, &self.defines, Some(self.context))?.to_bool())
     }
 
     fn evaluate(&mut self) -> bool {

--- a/crates/dreammaker/src/preprocessor.rs
+++ b/crates/dreammaker/src/preprocessor.rs
@@ -616,7 +616,7 @@ impl<'ctx> Preprocessor<'ctx> {
             start,
             self.output.drain(..),
         )?;
-        Ok(crate::constants::preprocessor_evaluate(start, expr, &self.defines)?.to_bool())
+        Ok(crate::constants::preprocessor_evaluate(start, expr, &self.defines, Some(&self.env_file))?.to_bool())
     }
 
     fn evaluate(&mut self) -> bool {


### PR DESCRIPTION
The way I implemented const-eval'd fexists is slightly incorrect.
It's evaulating the existence of the path relative to the invocation of the library or something, instead of relative to the ~~dme~~ current file.
This is causing errors in StrongDMM, because it's checking paths relative to the application exe file.

I tested by building StrongDMM and using this fixed version, and it worked correctly.