### PR TITLE
Fix `dreammaker.debugServerDll` accepting empty strings

### DIFF
--- a/crates/dm-langserver/src/main.rs
+++ b/crates/dm-langserver/src/main.rs
@@ -2080,10 +2080,16 @@ handle_notification! {
     }
 
     on DidChangeConfiguration(&mut self, params) {
-        if let Some(extools_dll) = params.settings["dreammaker"]["extoolsDLL"].as_str() {
+        if let Some(extools_dll) = params.settings["dreammaker"]["extoolsDLL"]
+            .as_str()
+            .filter(|path| !path.trim().is_empty())
+        {
             self.extools_dll = Some(extools_dll.to_owned());
         }
-        if let Some(debug_server_dll) = params.settings["dreammaker"]["debugServerDll"].as_str() {
+        if let Some(debug_server_dll) = params.settings["dreammaker"]["debugServerDll"]
+            .as_str()
+            .filter(|path| !path.trim().is_empty())
+        {
             self.debug_server_dll = Some(debug_server_dll.to_owned());
         }
     }


### PR DESCRIPTION
This makes it so blank strings are filtered out of `dreammaker.debugServerDll` (and also `dreammaker.extoolsDLL`, but I highly doubt that is still in use at all), so the config option being a blank string will just be treated as if said config option were unset.