### PR TITLE
Basic support for `for (var/k, v in X)` syntax

### DIFF
--- a/crates/dm-langserver/src/find_references.rs
+++ b/crates/dm-langserver/src/find_references.rs
@@ -325,7 +325,8 @@ impl<'o> WalkProc<'o> {
             Statement::Goto(_) => {},
             Statement::Crash(_) => {},
             Statement::Label { name: _, block } => self.visit_block(block),
-            Statement::Del(expr) => { self.visit_expression(location, expr, None); },
+            Statement::Del(expr) => { self.visit_expression(location, expr, None); }, // UUuuh
+            Statement::ForKeyValue(_) => { println!("correctly found a kv pair but no idea what do lol!")},
         }
     }
 

--- a/crates/dm-langserver/src/find_references.rs
+++ b/crates/dm-langserver/src/find_references.rs
@@ -333,8 +333,15 @@ impl<'o> WalkProc<'o> {
                 }
                 if let Some(var_type) = var_type {
                     self.visit_var(location, var_type, key, None);
-                    self.visit_var(location, var_type, value, None);
                 }
+                // the "v" in a DM for (var/k, v) statement is essentially typeless.
+                // There is currently no way to change that.
+                let var_type_value = VarType {
+                    flags: VarTypeFlags::from_bits_truncate(0),
+                    type_path: Box::new([]),
+                    input_type: InputType::from_bits_truncate(0),
+                };
+                self.visit_var(location, &var_type_value, value, None);
                 self.visit_block(block);
             },
         }

--- a/crates/dm-langserver/src/find_references.rs
+++ b/crates/dm-langserver/src/find_references.rs
@@ -325,8 +325,18 @@ impl<'o> WalkProc<'o> {
             Statement::Goto(_) => {},
             Statement::Crash(_) => {},
             Statement::Label { name: _, block } => self.visit_block(block),
-            Statement::Del(expr) => { self.visit_expression(location, expr, None); }, // UUuuh
-            Statement::ForKeyValue(_) => { println!("correctly found a kv pair but no idea what do lol!")},
+            Statement::Del(expr) => { self.visit_expression(location, expr, None); },
+            Statement::ForKeyValue(for_key_value) => {
+                let ForKeyValueStatement { var_type, key, value, in_list, block } = &**for_key_value;
+                if let Some(in_list) = in_list {
+                    self.visit_expression(location, in_list, None);
+                }
+                if let Some(var_type) = var_type {
+                    self.visit_var(location, var_type, key, None);
+                    self.visit_var(location, var_type, value, None);
+                }
+                self.visit_block(block);
+            },
         }
     }
 

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1597,8 +1597,15 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 // only the type of the key is taken into account
                 if let Some(var_type) = var_type {
                     self.visit_var(location, var_type, key, None, &mut scoped_locals);
-                    self.visit_var(location, var_type, value, None, &mut scoped_locals);
                 }
+                // the "v" in a DM for (var/k, v) statement is essentially typeless.
+                // There is currently no way to change that.
+                let var_type_value = VarType {
+                    flags: VarTypeFlags::from_bits_truncate(0),
+                    type_path: Box::new([]),
+                    input_type: InputType::from_bits_truncate(0),
+                };
+                self.visit_var(location, &var_type_value, value, None, &mut scoped_locals);
                 let mut state = self.visit_block(block, &mut scoped_locals);
                 state.end_loop();
                 return state

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1601,9 +1601,9 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 // the "v" in a DM for (var/k, v) statement is essentially typeless.
                 // There is currently no way to change that.
                 let var_type_value = VarType {
-                    flags: VarTypeFlags::from_bits_truncate(0),
+                    flags: VarTypeFlags::default(),
                     type_path: Box::new([]),
-                    input_type: InputType::from_bits_truncate(0),
+                    input_type: InputType::default(),
                 };
                 self.visit_var(location, &var_type_value, value, None, &mut scoped_locals);
                 let mut state = self.visit_block(block, &mut scoped_locals);

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1561,6 +1561,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             Statement::Goto(_) => {},
             Statement::Label { name: _, block } => { self.visit_block(block, &mut local_vars.clone()); },
             Statement::Del(expr) => { self.visit_expression(location, expr, None, local_vars); },
+            Statement::ForKeyValue(_) => { println!("correctly found a kv pair but no idea what do lol!")},
         }
         ControlFlow::allfalse()
     }

--- a/crates/dreamchecker/tests/branch_eval_tests.rs
+++ b/crates/dreamchecker/tests/branch_eval_tests.rs
@@ -94,3 +94,17 @@ fn for_loop_condition() {
 "##.trim();
     check_errors_match(code, FOR_LOOP_CONDITION_ERRORS);
 }
+
+#[test]
+fn for_kv_check() {
+    let code = r##"
+/proc/test()
+    var/alist/A = alist()
+    for (var/k, v in A)
+        world.log << k
+        world.log << v
+
+"##.trim();
+    check_errors_match(code, NO_ERRORS);
+}
+

--- a/crates/dreamchecker/tests/branch_eval_tests.rs
+++ b/crates/dreamchecker/tests/branch_eval_tests.rs
@@ -108,3 +108,49 @@ fn for_kv_check() {
     check_errors_match(code, NO_ERRORS);
 }
 
+pub const FOR_KV_VAR_ERROR: &[(u32, u16, &str)] = &[
+    (3, 19, "for (var/key, value) requires a 'var' keyword"),
+];
+
+#[test]
+fn for_kv_var_check() {
+    let code = r##"
+/proc/test()
+    var/alist/A = alist()
+    for (k, v in A)
+        world.log << k
+        world.log << v
+
+"##.trim();
+    check_errors_match(code, FOR_KV_VAR_ERROR);
+}
+
+pub const FOR_KV_VALUE_ERROR: &[(u32, u16, &str)] = &[
+    (3, 23, "value must be a variable in a for (var/key, value) statement"),
+];
+
+#[test]
+fn for_kv_value_check() {
+    let code = r##"
+/proc/test()
+    var/alist/A = alist()
+    for (var/k, 0 in A)
+        world.log << k
+"##.trim();
+    check_errors_match(code, FOR_KV_VALUE_ERROR);
+}
+
+pub const FOR_KV_KEY_ERROR: &[(u32, u16, &str)] = &[
+    (3, 27, "cannot assigned a value to var/key in a for(var/key, value) statement"),
+];
+
+#[test]
+fn for_kv_key_check() {
+    let code = r##"
+/proc/test()
+    var/alist/A = alist()
+    for (var/k = 5, v in A)
+        world.log << k
+"##.trim();
+    check_errors_match(code, FOR_KV_KEY_ERROR);
+}

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -1392,6 +1392,7 @@ pub enum Statement {
         block: Block,
     },
     ForList(Box<ForListStatement>),
+    ForKeyValue(Box<ForKeyValueStatement>),
     ForRange(Box<ForRangeStatement>),
     Var(Box<VarStatement>),
     Vars(Vec<VarStatement>),
@@ -1444,6 +1445,15 @@ pub struct ForListStatement {
     pub name: Ident2,
     /// If zero, uses the declared type of the variable.
     pub input_type: Option<InputType>,
+    /// Defaults to 'world'.
+    pub in_list: Option<Expression>,
+    pub block: Block,
+}
+
+#[derive(Debug, Clone, PartialEq, GetSize)]
+pub struct ForKeyValueStatement {
+    pub key: Ident2,
+    pub value: Ident2,
     /// Defaults to 'world'.
     pub in_list: Option<Expression>,
     pub block: Block,

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -1452,6 +1452,7 @@ pub struct ForListStatement {
 
 #[derive(Debug, Clone, PartialEq, GetSize)]
 pub struct ForKeyValueStatement {
+    pub var_type: Option<VarType>,
     pub key: Ident2,
     pub value: Ident2,
     /// Defaults to 'world'.

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1460,7 +1460,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                             // this is a really terrible way to do this
                                 Some(Statement::Var(var_statement)) => match var_statement.value {
                                     None => (Some(var_statement.var_type), var_statement.name),
-                                    _ => return Err(self.error("cannot assigned a value in var/key for(var/key, value) statement")),
+                                    _ => return Err(self.error("cannot assigned a value to var/key in a for(var/key, value) statement")),
                                 },
                                 _ => return Err(self.error("for (var/key, value) requires a 'var' keyword")),
                             };
@@ -1468,7 +1468,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                             // It should also pass only if it's an ident
                             let value = match lhs.into_term() {
                                 Some(Term::Ident(value)) => value,
-                                _ => return Err(self.error("value must be a variable in for (var/key, value) statement")),
+                                _ => return Err(self.error("value must be a variable in a for (var/key, value) statement")),
                             };
                             // TODO : check if `x` is an ident/a "list()" or "alist()" statement ?
                             require!(self.exact(Token::Punct(Punctuation::RParen)));

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1447,35 +1447,37 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                     // for (..., ... in ...)
                     match test {
                         // This should necessarily be caught because the expression is going be
-                        //for(k, [v in x]) and [v in x] will be passed as BinaryOp::In
+                        //for(var/k, [v in x]) and [v in x] will be passed as BinaryOp::In
                         // This is a bit ugly but it workss
                        Some(Expression::BinaryOp {
                             op: BinaryOp::In,
                             lhs,
                             rhs,
                         }) => {
-                            // Init was a full-blown statement. We transform into into an expression
-                            let init_as_expr = match init {
-                                Some(Statement::Expr(expr)) => expr,
-                                _ => return Err(self.error("key must be a variable in for (key, value) statement")),
+                            // First thing first: for (var/k, v in x) REQUIRES the var/k.
+                            // This unboxes it and rejects other type for(x, [...]), for(0, [...])
+                            let (var_type, key) = match init {
+                            // this is a really terrible way to do this
+                                Some(Statement::Var(var_statement)) => match var_statement.value {
+                                    None => (Some(var_statement.var_type), var_statement.name),
+                                    _ => return Err(self.error("cannot assigned a value in var/key for(var/key, value) statement")),
+                                },
+                                _ => return Err(self.error("for (var/key, value) requires a 'var' keyword")),
                             };
-                            // Which passes if it's an ident
-                            let key = match init_as_expr.into_term() {
-                                Some(Term::Ident(key)) => key,
-                                _ => return Err(self.error("key must be a variable in for (key, value) statement")),
-                            };
-                            // Value should also pass only if it's an ident
+                            // Value is the lhs of for(var, k [v in x])
+                            // It should also pass only if it's an ident
                             let value = match lhs.into_term() {
                                 Some(Term::Ident(value)) => value,
-                                _ => return Err(self.error("value must be a variable in for (key, value) statement")),
+                                _ => return Err(self.error("value must be a variable in for (var/key, value) statement")),
                             };
+                            // TODO : check if `x` is an ident/a "list()" or "alist()" statement ?
                             require!(self.exact(Token::Punct(Punctuation::RParen)));
                             // Returns a for(k,v)
-                            println!("Correctly about to return a for(k,v)");
                             spanned(Statement::ForKeyValue(Box::new(ForKeyValueStatement{
+                                var_type: Some(var_type.expect("/")),
                                 key: key.into(),
                                 value: value.into(),
-                                in_list: Some(*rhs), // We'll assume the rhs of [v in x] is a list
+                                in_list: Some(*rhs), // We'll assume the rhs of [v in x] is a list. Any other case, DM will catch anyway.
                                 block: require!(self.block(&LoopContext::ForLoop)),
                             })))
                         }

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1442,14 +1442,13 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                         inc: inc.map(Box::new),
                         block: require!(self.block(&LoopContext::ForLoop)),
                     })
-                }
-                else {
+                } else {
                     // for (..., ... in ...)
                     match test {
                         // This should necessarily be caught because the expression is going be
                         //for(var/k, [v in x]) and [v in x] will be passed as BinaryOp::In
                         // This is a bit ugly but it workss
-                       Some(Expression::BinaryOp {
+                        Some(Expression::BinaryOp {
                             op: BinaryOp::In,
                             lhs,
                             rhs,
@@ -1468,12 +1467,14 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                             // It should also pass only if it's an ident
                             let value = match lhs.into_term() {
                                 Some(Term::Ident(value)) => value,
-                                _ => return Err(self.error("value must be a variable in a for (var/key, value) statement")),
+                                _ => return Err(self.error(
+                                    "value must be a variable in a for (var/key, value) statement",
+                                )),
                             };
                             // TODO : check if `x` is an ident/a "list()" or "alist()" statement ?
                             require!(self.exact(Token::Punct(Punctuation::RParen)));
                             // Returns a for(k,v)
-                            spanned(Statement::ForKeyValue(Box::new(ForKeyValueStatement{
+                            spanned(Statement::ForKeyValue(Box::new(ForKeyValueStatement {
                                 var_type: Some(var_type.expect("/")),
                                 key: key.into(),
                                 value: value.into(),
@@ -1860,6 +1861,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             Ok(None)
         }
     }
+
     fn semicolon(&mut self) -> Status<()> {
         if let Some(()) = self.exact(Token::Punct(Punctuation::Semicolon))? {
             SUCCESS

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1410,10 +1410,11 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             // for (Var = Low to High)
             require!(self.exact(Token::Punct(Punctuation::LParen)));
             let init = self.simple_statement(true, vars)?;
-            if let Some(()) = self.comma_or_semicolon()? {
-                // three-pronged loop form ("for loop")
+            // three-pronged loop form ("for loop")
+            if let Some(()) = self.semicolon()? {
+                // for(init; test; [inc])
                 let test = self.expression()?;
-                let inc = match self.comma_or_semicolon()? {
+                let inc = match self.semicolon()? {
                     Some(()) => self.simple_statement(false, vars)?,
                     None => None,
                 };
@@ -1424,6 +1425,73 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                     inc: inc.map(Box::new),
                     block: require!(self.block(&LoopContext::ForLoop)),
                 })
+            // ... copypasted but with commas
+            } else if let Some(()) = self.comma()? {
+                // for(init, test, [inc])
+                let test = self.expression()?;
+                let inc = match self.semicolon()? {
+                    Some(()) => self.simple_statement(false, vars)?,
+                    None => None,
+                };
+                // Increment exists
+                if inc.is_some() {
+                    require!(self.exact(Token::Punct(Punctuation::RParen)));
+                    spanned(Statement::ForLoop {
+                        init: init.map(Box::new),
+                        test: test.map(Box::new),
+                        inc: inc.map(Box::new),
+                        block: require!(self.block(&LoopContext::ForLoop)),
+                    })
+                }
+                else {
+                    // for (..., ... in ...)
+                    match test {
+                        // This should necessarily be caught because the expression is going be
+                        //for(k, [v in x]) and [v in x] will be passed as BinaryOp::In
+                        // This is a bit ugly but it workss
+                       Some(Expression::BinaryOp {
+                            op: BinaryOp::In,
+                            lhs,
+                            rhs,
+                        }) => {
+                            // Init was a full-blown statement. We transform into into an expression
+                            let init_as_expr = match init {
+                                Some(Statement::Expr(expr)) => expr,
+                                _ => return Err(self.error("key must be a variable in for (key, value) statement")),
+                            };
+                            // Which passes if it's an ident
+                            let key = match init_as_expr.into_term() {
+                                Some(Term::Ident(key)) => key,
+                                _ => return Err(self.error("key must be a variable in for (key, value) statement")),
+                            };
+                            // Value should also pass only if it's an ident
+                            let value = match lhs.into_term() {
+                                Some(Term::Ident(value)) => value,
+                                _ => return Err(self.error("value must be a variable in for (key, value) statement")),
+                            };
+                            require!(self.exact(Token::Punct(Punctuation::RParen)));
+                            // Returns a for(k,v)
+                            println!("Correctly about to return a for(k,v)");
+                            spanned(Statement::ForKeyValue(Box::new(ForKeyValueStatement{
+                                key: key.into(),
+                                value: value.into(),
+                                in_list: Some(*rhs), // We'll assume the rhs of [v in x] is a list
+                                block: require!(self.block(&LoopContext::ForLoop)),
+                            })))
+                        }
+                        // We will just assume everything else for(k, [...]) is a two-pronged for loop
+                        // for (init, test) {...}
+                        _ => {
+                            require!(self.exact(Token::Punct(Punctuation::RParen)));
+                            spanned(Statement::ForLoop {
+                                init: init.map(Box::new),
+                                test: test.map(Box::new),
+                                inc: inc.map(Box::new),
+                                block: require!(self.block(&LoopContext::ForLoop)),
+                            })
+                        }
+                    }
+                }
             } else if let Some(init) = init {
                 // in-list form ("for list")
                 let (var_type, name) = match init {
@@ -1783,10 +1851,15 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
         })))
     }
 
-    fn comma_or_semicolon(&mut self) -> Status<()> {
+    fn comma(&mut self) -> Status<()> {
         if let Some(()) = self.exact(Token::Punct(Punctuation::Comma))? {
             SUCCESS
-        } else if let Some(()) = self.exact(Token::Punct(Punctuation::Semicolon))? {
+        } else {
+            Ok(None)
+        }
+    }
+    fn semicolon(&mut self) -> Status<()> {
+        if let Some(()) = self.exact(Token::Punct(Punctuation::Semicolon))? {
             SUCCESS
         } else {
             Ok(None)

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1427,9 +1427,9 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 })
             // ... copypasted but with commas
             } else if let Some(()) = self.comma()? {
-                // for(init, test, [inc])
+                // for(init, test [, inc])
                 let test = self.expression()?;
-                let inc = match self.semicolon()? {
+                let inc = match self.comma()? {
                     Some(()) => self.simple_statement(false, vars)?,
                     None => None,
                 };


### PR DESCRIPTION
## What this does 

This add a new arm to the parser for the `for (var/k, v in X)` dict-like syntax that was added in 516.

## How this works

I have hijacked the arm that checks for this type of expressions : 

`for (init, test, inc)` or `for (init; test; inc)`

I have seperated it between `init; test; inc` (left untouched) and `init, test, inc`.
If `inc` is not None, I then check if `test` in a `BinaryOp::In` (something like `for(init, [x in y])`. If not I just assume it's a `for (init, test)` which is valid DM syntax.

I then check if `init` is a `var/k` type of statement, using copypaste. DM will not compile `for (k, v)` nor will it compile `for (var/k, var/v)`. 
I check if v is an ident.

If we're all good, I create a new type of structure `ForKeyValueStatement` and the lib.rs / findreferences.rs knows what to do with it.

## Cases tested : 

<details>
<summary>See unit tests in the Files Changed</summary>



```dm
for (var/k, v in L)
     world.log << k
     world.log << v
```
✅

```dm
for (k, v in L)
     world.log << k
     world.log << v
```
❌ "for (var/key, value) requires a 'var' keyword"

```dm
for (var/k = 1, v in L)
     world.log << k
     world.log << v
```
❌  "cannot assigned a value in var/key for(var/key, value) statement"

```dm
for (var/0, v in L)
     world.log << k
     world.log << v
```
❌  "path has no effect" (was already covered)

```dm
for (var/k, 0 in L)
     world.log << k
     world.log << v
```
❌ "value must be a variable in for (var/key, value) statement"
</details>

## Regression checks 

Both `for (i = 0, i < 10, i++)`, `for (i = 0, i < 10)` still pass.