### PR TITLE
Add support for `call_ext(LoadedFunc)` syntax

### DIFF
--- a/crates/dm-langserver/src/find_references.rs
+++ b/crates/dm-langserver/src/find_references.rs
@@ -521,7 +521,9 @@ impl<'o> WalkProc<'o> {
             },
             Term::ExternalCall { library_name, function_name, args } => {
                 self.visit_expression(location, library_name, None);
-                self.visit_expression(location, function_name, None);
+                if let Some(function_name) = function_name {
+                    self.visit_expression(location, function_name, None);
+                }
                 self.visit_arguments(location, args);
                 StaticType::None
             },

--- a/crates/dm-langserver/src/find_references.rs
+++ b/crates/dm-langserver/src/find_references.rs
@@ -519,11 +519,11 @@ impl<'o> WalkProc<'o> {
                 self.visit_arguments(location, args_2);
                 StaticType::None
             },
-            Term::ExternalCall { library_name, function_name, args } => {
-                self.visit_expression(location, library_name, None);
-                if let Some(function_name) = function_name {
-                    self.visit_expression(location, function_name, None);
+            Term::ExternalCall { library, function, args } => {
+                if let Some(library) = library {
+                    self.visit_expression(location, library, None);
                 }
+                self.visit_expression(location, function, None);
                 self.visit_arguments(location, args);
                 StaticType::None
             },

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1923,7 +1923,9 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             },
             Term::ExternalCall { library_name, function_name, args } => {
                 self.visit_expression(location, library_name, None, local_vars);
-                self.visit_expression(location, function_name, None, local_vars);
+                if let Some(function_name) = function_name {
+                    self.visit_expression(location, function_name, None, local_vars);
+                }
                 self.visit_arguments(location, args, local_vars);
                 Analysis::empty()  // TODO
             },

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1935,11 +1935,11 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 self.visit_arguments(location, rhs_args, local_vars);
                 Analysis::empty()  // TODO
             },
-            Term::ExternalCall { library_name, function_name, args } => {
-                self.visit_expression(location, library_name, None, local_vars);
-                if let Some(function_name) = function_name {
-                    self.visit_expression(location, function_name, None, local_vars);
+            Term::ExternalCall { library, function, args } => {
+                if let Some(library) = library {
+                    self.visit_expression(location, library, None, local_vars);
                 }
+                self.visit_expression(location, function, None, local_vars);
                 self.visit_arguments(location, args, local_vars);
                 Analysis::empty()  // TODO
             },

--- a/crates/dreamchecker/tests/call_ext_tests.rs
+++ b/crates/dreamchecker/tests/call_ext_tests.rs
@@ -2,19 +2,6 @@ extern crate dreamchecker as dc;
 
 use dc::test_helpers::*;
 
-pub const CALL_EXT_MISSING_ARG_ERRORS: &[(u32, u16, &str)] = &[
-    (2, 15, "got ')', expected one of: operator, field access, ','"),
-];
-
-#[test]
-fn call_ext_missing_arg() {
-    let code = r##"
-/proc/f()
-    call_ext(1)(3, 4, 5)
-"##.trim();
-    check_errors_match(code, CALL_EXT_MISSING_ARG_ERRORS);
-}
-
 pub const CALL_EXT_MISSING_CALL_ERRORS: &[(u32, u16, &str)] = &[
     (2, 19, "got ';', expected one of: '('"),
 ];

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -1071,8 +1071,8 @@ pub enum Term {
     DynamicCall(Box<[Expression]>, Box<[Expression]>),
     /// A use of the `call_ext()()` primitive.
     ExternalCall {
-        library_name: Box<Expression>,
-        function_name: Option<Box<Expression>>,
+        library: Option<Box<Expression>>,
+        function: Box<Expression>,
         args: Box<[Expression]>,
     },
     /// Unscoped `::A` is a shorthand for `global.A`

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -1072,7 +1072,7 @@ pub enum Term {
     /// A use of the `call_ext()()` primitive.
     ExternalCall {
         library_name: Box<Expression>,
-        function_name: Box<Expression>,
+        function_name: Option<Box<Expression>>,
         args: Box<[Expression]>,
     },
     /// Unscoped `::A` is a shorthand for `global.A`

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -2146,17 +2146,20 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 require!(self.arguments(&[], "call*")),
             ),
 
-            // term :: 'call_ext' (library_name, function_name) arglist
+            // term :: 'call_ext' (library_name, [function_name]) arglist
             Token::Ident(ref i, _) if i == "call_ext" => {
                 require!(self.exact(Token::Punct(Punctuation::LParen)));
                 let library_name = require!(self.expression());
-                require!(self.exact(Token::Punct(Punctuation::Comma)));
-                let function_name = require!(self.expression());
+                let function_name = if self.exact(Token::Punct(Punctuation::Comma))?.is_some() {
+                    Some(require!(self.expression()))
+                } else {
+                    None
+                };
                 require!(self.exact(Token::Punct(Punctuation::RParen)));
 
                 Term::ExternalCall {
                     library_name: Box::new(library_name),
-                    function_name: Box::new(function_name),
+                    function_name: function_name.map(Box::new),
                     args: require!(self.arguments(&[], "call_ext*")),
                 }
             },

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -2146,7 +2146,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 require!(self.arguments(&[], "call*")),
             ),
 
-            // term :: 'call_ext' (library, [function]) arglist
+            // term :: 'call_ext' ([library,] function) arglist
             Token::Ident(ref i, _) if i == "call_ext" => {
                 require!(self.exact(Token::Punct(Punctuation::LParen)));
                 let first = require!(self.expression());

--- a/crates/dreammaker/tests/expression_tests.rs
+++ b/crates/dreammaker/tests/expression_tests.rs
@@ -7,7 +7,8 @@ use dm::parser::*;
 fn parse_expr(f: &str) -> Expression {
     let context = Default::default();
     let lexer = Lexer::new(&context, Default::default(), f.as_bytes());
-    let result = parse_expression(&context, Default::default(), lexer).expect("failed to parse expression");
+    let result =
+        parse_expression(&context, Default::default(), lexer).expect("failed to parse expression");
     context.assert_success();
     result
 }
@@ -124,7 +125,72 @@ fn pointer_ops() {
             follow: vec![
                 Spanned::new(Default::default(), Follow::Unary(UnaryOp::Reference)),
                 Spanned::new(Default::default(), Follow::Unary(UnaryOp::Dereference)),
-            ].into_boxed_slice(),
+            ]
+            .into_boxed_slice(),
+        }
+    )
+}
+
+#[test]
+fn call_ext() {
+    assert_eq!(
+        parse_expr("call_ext(\"cat.dll\", \"meow\")(1, 2, 3)"),
+        Expression::Base {
+            term: Box::new(Spanned::new(
+                Default::default(),
+                Term::ExternalCall {
+                    library: Some(Box::new(Expression::from(Term::String(
+                        "cat.dll".to_owned()
+                    )))),
+                    function: Box::new(Expression::from(Term::String("meow".to_owned()))),
+                    args: Box::new([
+                        Expression::Base {
+                            term: Box::new(Spanned::new(Default::default(), Term::Int(1))),
+                            follow: Box::new([])
+                        },
+                        Expression::Base {
+                            term: Box::new(Spanned::new(Default::default(), Term::Int(2))),
+                            follow: Box::new([])
+                        },
+                        Expression::Base {
+                            term: Box::new(Spanned::new(Default::default(), Term::Int(3))),
+                            follow: Box::new([])
+                        }
+                    ])
+                }
+            )),
+            follow: Box::new([]),
+        }
+    )
+}
+
+#[test]
+fn loaded_call_ext() {
+    assert_eq!(
+        parse_expr("call_ext(loaded_cat_meow)(1, 2, 3)"),
+        Expression::Base {
+            term: Box::new(Spanned::new(
+                Default::default(),
+                Term::ExternalCall {
+                    library: None,
+                    function: Box::new(Expression::from(Term::Ident("loaded_cat_meow".to_owned()))),
+                    args: Box::new([
+                        Expression::Base {
+                            term: Box::new(Spanned::new(Default::default(), Term::Int(1))),
+                            follow: Box::new([])
+                        },
+                        Expression::Base {
+                            term: Box::new(Spanned::new(Default::default(), Term::Int(2))),
+                            follow: Box::new([])
+                        },
+                        Expression::Base {
+                            term: Box::new(Spanned::new(Default::default(), Term::Int(3))),
+                            follow: Box::new([])
+                        }
+                    ])
+                }
+            )),
+            follow: Box::new([]),
         }
     )
 }


### PR DESCRIPTION
this adds support for 516's `call_ext(LoadedFunc)` syntax (allowing either one or two args to `call_ext`)

the `call_ext_missing_arg` test is removed as a result, as `call_ext` with a single arg is now valid syntax.