### PR TITLE
Update `git2` to `0.20.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
  "bitflags 2.7.0",
  "libc",
@@ -1027,9 +1027,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.1+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
 dependencies = [
  "cc",
  "libc",

--- a/crates/dm-langserver/Cargo.toml
+++ b/crates/dm-langserver/Cargo.toml
@@ -23,12 +23,9 @@ foldhash = "0.1.3"
 
 [build-dependencies]
 chrono = "0.4.38"
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.20.2", default-features = false }
 sha256 = { version = "1.5.0", default-features = false }
 ureq = "2.10.1"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(auxtools_bundle)',
-    'cfg(extools_bundle)',
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(auxtools_bundle)', 'cfg(extools_bundle)'] }

--- a/crates/dmdoc/Cargo.toml
+++ b/crates/dmdoc/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 dreammaker = { path = "../dreammaker" }
 pulldown-cmark = "0.9.6"
 walkdir = "2.5.0"
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.20.2", default-features = false }
 maud = "0.25.0"
 foldhash = "0.1.3"
 
@@ -18,4 +18,4 @@ walkdir = "2.5.0"
 
 [build-dependencies]
 chrono = "0.4.38"
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.20.2", default-features = false }

--- a/crates/dmm-tools-cli/Cargo.toml
+++ b/crates/dmm-tools-cli/Cargo.toml
@@ -21,4 +21,4 @@ foldhash = "0.1.3"
 
 [build-dependencies]
 chrono = "0.4.38"
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.20.2", default-features = false }

--- a/crates/dreamchecker/Cargo.toml
+++ b/crates/dreamchecker/Cargo.toml
@@ -11,4 +11,4 @@ foldhash = "0.1.3"
 
 [build-dependencies]
 chrono = "0.4.38"
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.20.2", default-features = false }

--- a/crates/spaceman-dmm/Cargo.toml
+++ b/crates/spaceman-dmm/Cargo.toml
@@ -35,4 +35,4 @@ branch = "zenity"
 
 [build-dependencies]
 chrono = "0.4.19"
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.20.2", default-features = false }


### PR DESCRIPTION
This updates the `git2` crate to 0.20.2, as linking on Windows (except win7) is broken in Rust 1.87.0+ due to https://github.com/rust-lang/rust/pull/138233, which https://github.com/rust-lang/git2-rs/pull/1143 fixed in `git2` 0.20.1

I'd try to convert everything to gitoxide instead, but that's easier said than done