### PR TITLE
Linting for set SpacemanDMM_ statements that have no effect

### DIFF
--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1232,9 +1232,11 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                     .register(self.context);
                 return term // stop evaluating
             }
-            match stmt.elem {
-                Statement::Setting { .. } => {
-                    if !setting_allowed {
+            match &stmt.elem {
+                Statement::Setting { name, mode, value } => {
+                    // Defines like SHOULD_CALL_PARENT currently only work at the top
+                    // Built in settings like background can situationally work in control blocks but are already warned by dreammaker
+                    if !setting_allowed && name.starts_with("SpacemanDMM_") {
                         error(stmt.location, "set statement not at the top of the proc")
                             .with_errortype("set_has_no_effect")
                             .register(self.context);


### PR DESCRIPTION
Currently when a spaceman setting like `SHOULD_CALL_PARENT` comes after some other statement other than possibly another setting, it is silently ignored. This PR now errors in that situation. The checking is only performed on spaceman settings and not built in settings (e.g. `background`) because those can situationally be allowed in control statements so long as they otherwise would be at the top of the proc, but dreammaker will already warn for them if they would have no effect.

See below where red lined are the new lints, and yellow lined are the existing dreammaker warnings.
![image](https://github.com/user-attachments/assets/4fe70a7f-819b-458a-9960-557b7c5bf6ab)
