### PR TITLE
Booleans are now evaluated as their own Term, instead of being rendered as an Integer/Float

### DIFF
--- a/crates/dm-langserver/src/find_references.rs
+++ b/crates/dm-langserver/src/find_references.rs
@@ -416,6 +416,7 @@ impl<'o> WalkProc<'o> {
             Term::Null => StaticType::None,
             Term::Int(_) => StaticType::None,
             Term::Float(_) => StaticType::None,
+            Term::Boolean(_) => StaticType::None,
             Term::String(_) => StaticType::None,
             Term::Resource(_) => StaticType::None,
             Term::As(_) => StaticType::None,

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -134,8 +134,7 @@ impl<'o> AssumptionSet<'o> {
             Constant::Null(_) => assumption_set![Assumption::IsNull(true), Assumption::Truthy(false)],
             Constant::String(val) => assumption_set![Assumption::IsText(true), Assumption::Truthy(!val.is_empty())],
             Constant::Resource(_) => assumption_set![Assumption::Truthy(true)],
-            Constant::Float(val) => assumption_set![Assumption::IsNum(true), Assumption::Truthy(*val != 0.0)]
-            }
+            Constant::Float(val) => assumption_set![Assumption::IsNum(true), Assumption::Truthy(*val != 0.0)],
             Constant::Boolean(boolean) => assumption_set![Assumption::Truthy((*boolean))],
             Constant::List(_) => AssumptionSet::from_valid_instance(objtree.expect("/list")),
             Constant::Call(func, _) => match func {
@@ -1712,6 +1711,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         match term {
             Term::Null => Analysis::null(),
             Term::Int(number) => Analysis::from_value(self.objtree, Constant::from(*number), type_hint),
+            Term::Boolean(inner_boolean) => Analysis::from_value(self.objtree, Constant::from(*inner_boolean), type_hint),
             Term::Float(number) => Analysis::from_value(self.objtree, Constant::from(*number), type_hint),
             Term::String(text) => Analysis::from_value(self.objtree, Constant::String(text.as_str().into()), type_hint),
             Term::Resource(text) => Analysis::from_value(self.objtree, Constant::Resource(text.as_str().into()), type_hint),

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -135,7 +135,7 @@ impl<'o> AssumptionSet<'o> {
             Constant::String(val) => assumption_set![Assumption::IsText(true), Assumption::Truthy(!val.is_empty())],
             Constant::Resource(_) => assumption_set![Assumption::Truthy(true)],
             Constant::Float(val) => assumption_set![Assumption::IsNum(true), Assumption::Truthy(*val != 0.0)],
-            Constant::Boolean(boolean) => assumption_set![Assumption::Truthy((*boolean))],
+            Constant::Boolean(boolean) => assumption_set![Assumption::Truthy(*boolean)],
             Constant::List(_) => AssumptionSet::from_valid_instance(objtree.expect("/list")),
             Constant::Call(func, _) => match func {
                 ConstFn::Icon => AssumptionSet::from_valid_instance(objtree.expect("/icon")),

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -134,7 +134,9 @@ impl<'o> AssumptionSet<'o> {
             Constant::Null(_) => assumption_set![Assumption::IsNull(true), Assumption::Truthy(false)],
             Constant::String(val) => assumption_set![Assumption::IsText(true), Assumption::Truthy(!val.is_empty())],
             Constant::Resource(_) => assumption_set![Assumption::Truthy(true)],
-            Constant::Float(val) => assumption_set![Assumption::IsNum(true), Assumption::Truthy(*val != 0.0)],
+            Constant::Float(val) => assumption_set![Assumption::IsNum(true), Assumption::Truthy(*val != 0.0)]
+            }
+            Constant::Boolean(boolean) => assumption_set![Assumption::Truthy((*boolean))],
             Constant::List(_) => AssumptionSet::from_valid_instance(objtree.expect("/list")),
             Constant::Call(func, _) => match func {
                 ConstFn::Icon => AssumptionSet::from_valid_instance(objtree.expect("/icon")),

--- a/crates/dreammaker/src/ast.rs
+++ b/crates/dreammaker/src/ast.rs
@@ -1079,6 +1079,7 @@ pub enum Term {
     GlobalIdent(Ident2),
     /// Unscoped `::A(...)` is a shorthand for `global.A(...)`
     GlobalCall(Ident2, Box<[Expression]>),
+    Boolean(bool),
 }
 
 impl Term {

--- a/crates/dreammaker/src/builtins.rs
+++ b/crates/dreammaker/src/builtins.rs
@@ -228,6 +228,11 @@ pub fn register_builtins(tree: &mut ObjectTreeBuilder) {
             Constant::Float($e as f32)
         };
     }
+    macro_rules! boolean {
+        ($e:expr) => {
+            Constant::Boolean($e as bool)
+        };
+    }
     macro_rules! string {
         ($e:expr) => {
             Constant::String($e.into())
@@ -309,8 +314,8 @@ pub fn register_builtins(tree: &mut ObjectTreeBuilder) {
         var/const/TILED_ICON_MAP = int!(32768);
 
         #[dm_ref("/proc/if")] {
-            var/const/TRUE = int!(1);
-            var/const/FALSE = int!(0);
+            var/const/TRUE = boolean!(true);
+            var/const/FALSE = boolean!(false);
         }
 
         // enum /mob/var/gender

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -2220,7 +2220,8 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             },
 
             Token::Ident(ref i, _) if i == "null" => Term::Null,
-
+            Token::Ident(ref i, _) if i == "TRUE" => Term::Boolean(true),
+            Token::Ident(ref i, _) if i == "FALSE" => Term::Boolean(false),
             // term :: 'as' '(' input_type ')'
             Token::Ident(ref i, _) if i == "as" => {
                 require!(self.exact(Token::Punct(Punctuation::LParen)));


### PR DESCRIPTION
This PR adds booleans as an AST element, replacing the implementation where they're represented as literal 1 or 0 either as integers or floats.