### PR TITLE
Add an Option<Range<Location>> body_range field to ProcValue, for concise and lighter-weight reference

### DIFF
--- a/crates/dreammaker/src/objtree.rs
+++ b/crates/dreammaker/src/objtree.rs
@@ -93,8 +93,7 @@ pub struct ProcDeclaration {
     pub id: SymbolId,
 }
 
-fn heap_size_of_location_range(_range: &Option<Range<Location>>) -> usize
-{
+fn heap_size_of_location_range(_range: &Option<Range<Location>>) -> usize {
     size_of::<Range<Location>>()
 }
 
@@ -1135,7 +1134,7 @@ impl ObjectTreeBuilder {
         parameters: Vec<Parameter>,
         return_type: ProcReturnType,
         code: Option<Block>,
-        body_range: Option<Range<Location>>
+        body_range: Option<Range<Location>>,
     ) -> Result<(usize, &mut ProcValue), DMError> {
         let node = &mut self.inner.graph[parent.index()];
         let proc = node.procs.entry(name.to_owned()).or_insert_with(|| TypeProc {
@@ -1163,7 +1162,7 @@ impl ObjectTreeBuilder {
             parameters: parameters.into(),
             docs: Default::default(),
             code,
-            body_range
+            body_range,
         };
 
         // DM really does reorder the declaration to appear before the override,
@@ -1251,7 +1250,7 @@ impl ObjectTreeBuilder {
             elems.len() + 1,
             params.iter().copied().map(|param| Parameter { name: param.into(), .. Default::default() }).collect(),
             None,
-            None
+            None,
         ).unwrap().1
     }
 

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1142,7 +1142,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             None
         };
 
-        match self.tree.register_proc(self.context, location, current, name, proc_builder, parameters, return_type, code) {
+        match self.tree.register_proc(self.context, location, current, name, proc_builder, parameters, return_type, code, Some(Range{start: body_start, end: self.location})) {
             Ok((idx, proc)) => {
                 proc.docs.extend(docs);
                 // manually performed for borrowck reasons

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1142,7 +1142,7 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
             None
         };
 
-        match self.tree.register_proc(self.context, location, current, name, proc_builder, parameters, return_type, code, Some(Range{start: body_start, end: self.location})) {
+        match self.tree.register_proc(self.context, location, current, name, proc_builder, parameters, return_type, code, Some(body_start..self.location)) {
             Ok((idx, proc)) => {
                 proc.docs.extend(docs);
                 // manually performed for borrowck reasons


### PR DESCRIPTION
I wasn't able to find a concise way to reference the range and/or contents of proc bodies without also needing to reference the Annotation tree. I haven't implemented any use case for the added information outside of some experiments I'm doing with the deeper analysis companion; I think it could be useful for determining return values and types without the need for SpacemanDMM directives, at a later point.

It's an Option to account for built-ins not having any actual presence in the syntax tree.