### PR TITLE
Add the missing sign(A) builtin proc

### DIFF
--- a/crates/dreammaker/src/builtins.rs
+++ b/crates/dreammaker/src/builtins.rs
@@ -536,6 +536,7 @@ pub fn register_builtins(tree: &mut ObjectTreeBuilder) {
         proc/run(File);
         proc/shell(Command);
         proc/shutdown(Addr,Natural=0);
+        proc/sign(A);
         proc/sin(X);
         proc/sleep(Delay);
         proc/sorttext(T1,T2/*,...*/);


### PR DESCRIPTION
It's not tagged with a version in the DM reference, so I assume it's always been there, but got missed when this list was created.