### PR TITLE
fix pixloc

### DIFF
--- a/crates/dreammaker/src/builtins.rs
+++ b/crates/dreammaker/src/builtins.rs
@@ -1269,9 +1269,9 @@ pub fn register_builtins(tree: &mut ObjectTreeBuilder) {
         pixloc/var/atom/loc;
         pixloc/var/step_x;
         pixloc/var/step_y;
-        pixloc/x;
-        pixloc/y;
-        pixloc/z;
+        pixloc/var/x;
+        pixloc/var/y;
+        pixloc/var/z;
 
         proc/vector(x, y, z);
 


### PR DESCRIPTION
`undefined field: "x" on /pixloc`
`undefined field: "y" on /pixloc`