### PR TITLE
Fix alists not being marked as iterable

### DIFF
--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -1433,7 +1433,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                         }
                         StaticType::List { .. } => {/* OK */}
                         StaticType::Type(ty) => {
-                            if ty != self.objtree.expect("/world") && ty != self.objtree.expect("/list") {
+                            if ty != self.objtree.expect("/world") && ty != self.objtree.expect("/list") && ty != self.objtree.expect("/alist") {
                                 let atom = self.objtree.expect("/atom");
                                 if ty.is_subtype_of(&atom) {
                                     // Fine.


### PR DESCRIPTION
Trying to loop over values using `for(var/v in alist("a" = 2))` would throw an "iterating over a /alist which cannot be iterated" error despite working in DM.