### PR TITLE
replace linear algebra types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,11 +489,13 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "bytemuck",
+ "derive_more",
  "dreammaker",
  "either",
  "foldhash",
  "gfx_core",
  "gif",
+ "glam",
  "indexmap",
  "inflate",
  "lodepng",
@@ -776,6 +799,12 @@ dependencies = [
  "log",
  "url",
 ]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 
 [[package]]
 name = "hashbrown"
@@ -1508,6 +1537,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1600,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "foldhash",
  "get-size",
  "get-size-derive",
+ "glam",
  "indexmap",
  "interval-tree",
  "lodepng",

--- a/crates/dmm-tools/Cargo.toml
+++ b/crates/dmm-tools/Cargo.toml
@@ -13,6 +13,8 @@ lodepng = "3.10.7"
 indexmap = "2.6.0"
 foldhash = "0.2.0"
 either = "1.13.0"
+glam = "0.30"
+derive_more = {version = "2.1.1", features = ["deref"]}
 
 [dependencies.bytemuck]
 version = "1.19.0"

--- a/crates/dmm-tools/src/dmm.rs
+++ b/crates/dmm-tools/src/dmm.rs
@@ -62,6 +62,14 @@ impl Coord2 {
     }
 }
 
+impl std::ops::Add<Dir> for Coord2 {
+    type Output = Coord2;
+
+    fn add(self, rhs: Dir) -> Coord2 {
+        Coord2(self.0 + rhs.offset())
+    }
+}
+
 impl From<IVec2> for Coord2 {
     fn from(value: IVec2) -> Self {
         Self(value)

--- a/crates/dreammaker/Cargo.toml
+++ b/crates/dreammaker/Cargo.toml
@@ -22,6 +22,7 @@ derivative = "2.2.0"
 get-size = "0.1.4"
 get-size-derive = "0.1.3"
 beef = "0.5.2"
+glam = "0.30"
 
 [dev-dependencies]
 walkdir = "2.5.0"

--- a/crates/dreammaker/src/dmi.rs
+++ b/crates/dreammaker/src/dmi.rs
@@ -1,6 +1,7 @@
 //! DMI metadata parsing and representation.
 
 use foldhash::{HashMap, HashMapExt};
+use glam::IVec2;
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::io;
@@ -190,16 +191,16 @@ impl Dir {
     }
 
     /// Get this direction's offset in BYOND's coordinate system.
-    pub fn offset(self) -> (i32, i32) {
+    pub fn offset(self) -> IVec2 {
         match self {
-            Dir::North => (0, 1),
-            Dir::South => (0, -1),
-            Dir::East => (1, 0),
-            Dir::West => (-1, 0),
-            Dir::Northeast => (1, 1),
-            Dir::Northwest => (-1, 1),
-            Dir::Southeast => (1, -1),
-            Dir::Southwest => (-1, -1),
+            Dir::North => IVec2::new(0, 1),
+            Dir::South => IVec2::new(0, -1),
+            Dir::East => IVec2::new(1, 0),
+            Dir::West => IVec2::new(-1, 0),
+            Dir::Northeast => IVec2::new(1, 1),
+            Dir::Northwest => IVec2::new(-1, 1),
+            Dir::Southeast => IVec2::new(1, -1),
+            Dir::Southwest => IVec2::new(-1, -1),
         }
     }
 }


### PR DESCRIPTION
Refactored `Coord2` and `Coord3` to instead use `glam` types, so as to reduce potential overhead from maintaining i32 vector types that have already been implemented. Struct identifiers were retained, so as to enable implementation of operations that are specific to the scope of BYOND.