### PR TITLE
Adds AnnotationTree::ProcParameter(VarType, Ident); annotates the parameters and their typepath/input type

### DIFF
--- a/crates/dreammaker/src/annotation.rs
+++ b/crates/dreammaker/src/annotation.rs
@@ -19,6 +19,7 @@ pub enum Annotation {
     TypePath(TypePath),
     Variable(Vec<Ident>),
     ProcHeader(Vec<Ident>, usize),
+    ProcParameter(VarType, Ident),
     ProcBody(Vec<Ident>, usize),
     LocalVarScope(VarType, Ident),
 

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1359,6 +1359,8 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 .with_errortype("semicolon_in_proc_parameter")
                 .register(self.context);
         }
+        let end = self.updated_location();
+        self.annotate_precise(leading_loc..end, || Annotation::ProcParameter(var_type.clone().build(), name.clone()));
 
         success(Parameter {
             var_type: var_type.build(),

--- a/crates/dreammaker/src/parser.rs
+++ b/crates/dreammaker/src/parser.rs
@@ -1360,7 +1360,9 @@ impl<'ctx, 'an, 'inp> Parser<'ctx, 'an, 'inp> {
                 .register(self.context);
         }
         let end = self.updated_location();
-        self.annotate_precise(leading_loc..end, || Annotation::ProcParameter(var_type.clone().build(), name.clone()));
+        let mut var_annotation = var_type.clone();
+        var_annotation.input_type = input_type;
+        self.annotate_precise(leading_loc..end, || Annotation::ProcParameter(var_annotation.build(), name.clone()));
 
         success(Parameter {
             var_type: var_type.build(),


### PR DESCRIPTION
This is mostly to simplify some work I'm doing to use SpacemanDMM as a refactoring tool, but it could also serve to validate proc arguments at compile time. I'd have to do more digging to be sure of it, but I also think it could be used to simplify some of the logic for things like Hover for when it's determining the type of an UnscopedVar.