### PR TITLE
Add option for `dmm-tools` to not print errors

### DIFF
--- a/crates/dmm-tools-cli/src/main.rs
+++ b/crates/dmm-tools-cli/src/main.rs
@@ -306,6 +306,7 @@ fn run(opt: &Opt, command: &Command, context: &mut Context) {
                         render_passes,
                         errors: &errors,
                         bump: &bump,
+                        print_errors: true,
                     };
                     let image = minimap::generate(minimap_context, icon_cache).unwrap();
                     if let Err(e) = std::fs::create_dir_all(output) {
@@ -650,6 +651,7 @@ fn render_many(context: &Context, command: RenderManyCommand) -> RenderManyComma
                         render_passes,
                         errors: &errors,
                         bump: &bump,
+                        print_errors: true,
                     };
                     let image = minimap::generate(minimap_context, icon_cache).unwrap(); // TODO: error handling
 

--- a/crates/dmm-tools/src/minimap.rs
+++ b/crates/dmm-tools/src/minimap.rs
@@ -27,6 +27,7 @@ pub struct Context<'a> {
     pub render_passes: &'a [Box<dyn RenderPass>],
     pub errors: &'a RwLock<HashSet<String>>,
     pub bump: &'a bumpalo::Bump,
+    pub print_errors: bool,
 }
 
 // This should eventually be faliable and not just shrug it's shoulders at errors and log them.
@@ -52,7 +53,7 @@ pub fn generate(ctx: Context, icon_cache: &IconCache) -> Result<Image, ()> {
     for (key, prefabs) in map.dictionary.iter() {
         atoms.insert(
             key,
-            get_atom_list(objtree, prefabs, render_passes, ctx.errors),
+            get_atom_list(objtree, prefabs, render_passes, ctx.errors, ctx.print_errors),
         );
     }
 
@@ -84,7 +85,9 @@ pub fn generate(ctx: Context, icon_cache: &IconCache) -> Result<Image, ()> {
                     pass.adjust_sprite(atom, &mut sprite, objtree, bump);
                 }
                 if sprite.icon.is_empty() {
-                    println!("no icon: {}", atom.type_.path);
+                    if ctx.print_errors {
+                        eprintln!("no icon: {}", atom.type_.path);
+                    }
                     continue;
                 }
                 let atom = Atom { sprite, ..*atom };
@@ -174,7 +177,9 @@ pub fn generate(ctx: Context, icon_cache: &IconCache) -> Result<Image, ()> {
                 sprite.icon, sprite.icon_state
             );
             if !ctx.errors.read().unwrap().contains(&key) {
-                eprintln!("{key}");
+                if ctx.print_errors {
+                    eprintln!("{key}");
+                }
                 ctx.errors.write().unwrap().insert(key);
             }
         }
@@ -215,6 +220,7 @@ fn get_atom_list<'a>(
     prefabs: &'a [Prefab],
     render_passes: &[Box<dyn RenderPass>],
     errors: &RwLock<HashSet<String>>,
+    print_errors: bool,
 ) -> Vec<Atom<'a>> {
     let mut result = Vec::new();
 
@@ -231,7 +237,9 @@ fn get_atom_list<'a>(
             None => {
                 let key = format!("bad path: {}", fab.path);
                 if !errors.read().unwrap().contains(&key) {
-                    println!("{key}");
+                    if print_errors {
+                        eprintln!("{key}");
+                    }
                     errors.write().unwrap().insert(key);
                 }
                 continue;


### PR DESCRIPTION
this adds a `print_errors` bool to `Context` in `dmm-tools` - which is exactly what it says on the tin. it toggles whether the dmm-tools parser will print errors to stderr or not.

this came to be bc the `bad icon` stuff kept causing issues with my fancy cli progress bars in https://github.com/Absolucy/ss13-webmapgen :(

also fixed a few of the errors going to stdout instead of stderr...