### PR TITLE
Add vector() to compile time functions

### DIFF
--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -164,6 +164,7 @@ impl<'o> AssumptionSet<'o> {
                 ConstFn::Generator => {
                     AssumptionSet::from_valid_instance(objtree.expect("/generator"))
                 },
+                ConstFn::Vector => AssumptionSet::from_valid_instance(objtree.expect("/vector")),
                 ConstFn::Filter => AssumptionSet::default(),
                 ConstFn::File => AssumptionSet::default(),
             },

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -175,7 +175,7 @@ pub enum ConstFn {
     /// The `generator()` type constructor.
     Generator,
     /// The `vector()` type constructor.
-    Vector
+    Vector,
 }
 
 /// A constant-evaluation error (usually type mismatch).
@@ -437,7 +437,7 @@ impl fmt::Display for ConstFn {
             ConstFn::Filter => "filter",
             ConstFn::File => "file",
             ConstFn::Generator => "generator",
-            ConstFn::Vector => "vector"
+            ConstFn::Vector => "vector",
         })
     }
 }

--- a/crates/dreammaker/src/constants.rs
+++ b/crates/dreammaker/src/constants.rs
@@ -174,6 +174,8 @@ pub enum ConstFn {
     File,
     /// The `generator()` type constructor.
     Generator,
+    /// The `vector()` type constructor.
+    Vector
 }
 
 /// A constant-evaluation error (usually type mismatch).
@@ -435,6 +437,7 @@ impl fmt::Display for ConstFn {
             ConstFn::Filter => "filter",
             ConstFn::File => "file",
             ConstFn::Generator => "generator",
+            ConstFn::Vector => "vector"
         })
     }
 }
@@ -847,6 +850,7 @@ impl<'a> ConstantFolder<'a> {
                 "filter" => Constant::Call(ConstFn::Filter, self.arguments(args)?),
                 "file" => Constant::Call(ConstFn::File, self.arguments(args)?),
                 "generator" => Constant::Call(ConstFn::Generator, self.arguments(args)?),
+                "vector" => Constant::Call(ConstFn::Vector, self.arguments(args)?),
                 // constant-evaluatable functions
                 "sin" => self.trig_op(args, f32::sin)?,
                 "cos" => self.trig_op(args, f32::cos)?,


### PR DESCRIPTION
It's a compile time function (functionally, I suspect in the same gender as list() though I have not tested) so we shouldn't warn like this.

Closes #467 