### PR TITLE
Fix empty variadic macros dropping LHS of token pasting

### DIFF
--- a/crates/dreammaker/src/preprocessor.rs
+++ b/crates/dreammaker/src/preprocessor.rs
@@ -1281,7 +1281,9 @@ impl<'ctx> Preprocessor<'ctx> {
                                                             .push_back(Token::Ident(first, ws1));
                                                         expansion.push_back(other);
                                                     },
-                                                    None => {},
+                                                    None => {
+                                                        expansion.push_back(Token::Ident(first, ws1));
+                                                    },
                                                 }
                                                 expansion.extend(arg);
                                             },


### PR DESCRIPTION
say you were wanting to do something like

```dm
#define MACRO_THAT_MAKES_A_VAR(var_name, var_type...) var##var_type/##var_name

/proc/foo()
  MACRO_THAT_MAKES_A_VAR(some_primitive) // var/some_primitive
  MACRO_THAT_MAKES_A_VAR(typed_var, /client) // /var/client/some_primitive
```

we currently drop the var from the expression, and would just emit /some_primitive