### PR TITLE
Fixes SHOULD_NOT_SLEEP() missing situations where sleep is in fact called

### DIFF
--- a/crates/dreamchecker/README.md
+++ b/crates/dreamchecker/README.md
@@ -62,6 +62,7 @@ be enabled:
 	#define UNLINT(X) SpacemanDMM_unlint(X)
 	#define SHOULD_NOT_OVERRIDE(X) set SpacemanDMM_should_not_override = X
 	#define SHOULD_NOT_SLEEP(X) set SpacemanDMM_should_not_sleep = X
+	#define ALLOWED_TO_SLEEP(X) set SpacemanDMM_allowed_to_sleep = X
 	#define SHOULD_BE_PURE(X) set SpacemanDMM_should_be_pure = X
 	#define PRIVATE_PROC(X) set SpacemanDMM_private_proc = X
 	#define PROTECTED_PROC(X) set SpacemanDMM_protected_proc = X
@@ -75,6 +76,7 @@ be enabled:
 	#define UNLINT(X) X
 	#define SHOULD_NOT_OVERRIDE(X)
 	#define SHOULD_NOT_SLEEP(X)
+	#define ALLOWED_TO_SLEEP(X)
 	#define SHOULD_BE_PURE(X)
 	#define PRIVATE_PROC(X)
 	#define PROTECTED_PROC(X)

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -594,6 +594,12 @@ impl<'o> ViolatingOverrides<'o> {
     }
 }
 
+/// An edge in the call tree: the proc called, where it was called, whether the
+/// call was made in a new context (`spawn`), the static type of the receiver,
+/// and whether the call is exact (`..()`, `new`, self- and global calls, which
+/// never dispatch to an override).
+type CallEdge<'o> = (ProcRef<'o>, Location, bool, TypeRef<'o>, bool);
+
 /// A deeper analysis of an ObjectTree
 pub struct AnalyzeObjectTree<'o> {
     context: &'o Context,
@@ -611,14 +617,13 @@ pub struct AnalyzeObjectTree<'o> {
     // Debug(ProcRef) -> KwargInfo
     used_kwargs: BTreeMap<String, KwargInfo>,
 
-    call_tree: HashMap<ProcRef<'o>, Vec<(ProcRef<'o>, Location, bool)>>,
+    call_tree: HashMap<ProcRef<'o>, Vec<CallEdge<'o>>>,
 
     sleeping_procs: ViolatingProcs<'o>,
     impure_procs: ViolatingProcs<'o>,
     /// Procs with waitfor=0 or waitfor=FALSE
     waitfor_procs: HashSet<ProcRef<'o>>,
 
-    sleeping_overrides: ViolatingOverrides<'o>,
     impure_overrides: ViolatingOverrides<'o>,
 }
 
@@ -662,7 +667,6 @@ impl<'o> AnalyzeObjectTree<'o> {
             sleeping_procs: Default::default(),
             impure_procs: Default::default(),
             waitfor_procs: Default::default(),
-            sleeping_overrides: Default::default(),
             impure_overrides: Default::default(),
         }
     }
@@ -728,7 +732,20 @@ impl<'o> AnalyzeObjectTree<'o> {
     }
 
     pub fn check_proc_call_tree(&mut self) {
+        // prepare for the worst case, avoiding the reallocations _is_ faster and less memory expensive
+        let total_procs = self
+            .objtree
+            .iter_types()
+            .flat_map(|type_ref: TypeRef| type_ref.iter_self_procs())
+            .count();
+        let mut visited = HashSet::<ProcRef<'o>>::with_capacity(total_procs);
+        let mut to_visit =
+            VecDeque::<(ProcRef<'o>, CallStack, bool, ProcRef<'o>, TypeRef<'o>, bool)>::new();
         for (procref, &(_, location)) in self.must_not_sleep.directive.iter() {
+            if !visited.insert(*procref) {
+                continue;
+            }
+
             if let Some(sleepvec) = self.sleeping_procs.get_violators(*procref) {
                 error(procref.get().location, format!("{procref} sets SpacemanDMM_should_not_sleep but calls blocking built-in(s)"))
                     .with_note(location, "SpacemanDMM_should_not_sleep set here")
@@ -736,16 +753,22 @@ impl<'o> AnalyzeObjectTree<'o> {
                     .with_blocking_builtins(sleepvec)
                     .register(self.context)
             }
-            let mut visited = HashSet::<ProcRef<'o>>::new();
-            let mut to_visit = VecDeque::<(ProcRef<'o>, CallStack, bool)>::new();
-            if let Some(procscalled) = self.call_tree.get(procref) {
-                for (proccalled, location, new_context) in procscalled {
-                    let mut callstack = CallStack::default();
-                    callstack.add_step(*proccalled, *location, *new_context);
-                    to_visit.push_back((*proccalled, callstack, *new_context));
+
+            if let Some(calledvec) = self.call_tree.get(procref) {
+                for (proccalled, location, new_context, src, is_exact) in calledvec.iter() {
+                    let mut newstack = CallStack::default();
+                    newstack.add_step(*proccalled, *location, *new_context);
+                    to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, *src, *is_exact));
                 }
             }
-            while let Some((nextproc, callstack, new_context)) = to_visit.pop_front() {
+
+            let procref_type_index = procref.ty().index();
+            while let Some((nextproc, callstack, new_context, parent_proc, src, is_exact)) =
+                to_visit.pop_front()
+            {
+                if new_context {
+                    continue;
+                }
                 if !visited.insert(nextproc) {
                     continue;
                 }
@@ -755,42 +778,55 @@ impl<'o> AnalyzeObjectTree<'o> {
                 if self.sleep_exempt.get(nextproc).is_some() {
                     continue;
                 }
-                if new_context {
-                    continue;
-                }
+
                 if let Some(sleepvec) = self.sleeping_procs.get_violators(nextproc) {
-                    error(procref.get().location, format!("{procref} sets SpacemanDMM_should_not_sleep but calls blocking proc {nextproc}"))
+                    let parent_proc_type_index = parent_proc.ty().index();
+                    let next_proc_type_index = nextproc.ty().index();
+
+                    let proc_is_on_same_type_as_setting = next_proc_type_index == procref_type_index;
+                    let proc_is_override = next_proc_type_index != parent_proc_type_index;
+
+                    let desc = if proc_is_on_same_type_as_setting && proc_is_override {
+                        format!("{procref} sets SpacemanDMM_should_not_sleep but has override child proc that sleeps {nextproc}")
+                    } else if proc_is_override {
+                        format!("{procref} calls {parent_proc} which has override child proc that sleeps {nextproc}")
+                    } else {
+                        format!("{procref} sets SpacemanDMM_should_not_sleep but calls blocking proc {nextproc}")
+                    };
+
+                    error(procref.get().location, desc)
                         .with_note(location, "SpacemanDMM_should_not_sleep set here")
                         .with_errortype("must_not_sleep")
                         .with_callstack(&callstack)
                         .with_blocking_builtins(sleepvec)
-                        .register(self.context)
-                } else if let Some(overridesleep) =
-                    self.sleeping_overrides.get_override_violators(nextproc)
-                {
-                    for child_violator in overridesleep {
-                        if procref.ty().is_subtype_of(&nextproc.ty())
-                            && !child_violator.ty().is_subtype_of(&procref.ty())
-                        {
-                            continue;
-                        }
-                        error(procref.get().location, format!("{procref} calls {nextproc} which has override child proc that sleeps {child_violator}"))
-                            .with_note(location, "SpacemanDMM_should_not_sleep set here")
-                            .with_errortype("must_not_sleep")
-                            .with_callstack(&callstack)
-                            .with_blocking_builtins(self.sleeping_procs.get_violators(*child_violator).unwrap())
-                            .register(self.context)
-                    }
+                        .register(self.context);
+
+                    // Abort now, we don't want to go unnecessarily deep
+                    continue;
                 }
+
+                // Dispatch is bounded by the receiver's static type: an
+                // override can only be reached if its type is `src` or a
+                // descendant of it. Exact calls (`..()`, `new`, self-calls,
+                // global calls) never dispatch to an override at all.
+                if !is_exact && nextproc.ty().index() != self.objtree.root().index() {
+                    nextproc.recurse_children_within(src, &mut |child_proc| {
+                        to_visit.push_back((child_proc, callstack.clone(), false, nextproc, src, true));
+                    });
+                }
+
                 if let Some(calledvec) = self.call_tree.get(&nextproc) {
-                    for (proccalled, location, new_context) in calledvec.iter() {
+                    for (proccalled, location, new_context, call_src, call_is_exact) in calledvec.iter() {
                         let mut newstack = callstack.clone();
                         newstack.add_step(*proccalled, *location, *new_context);
-                        to_visit.push_back((*proccalled, newstack, *new_context));
+                        to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, *call_src, *call_is_exact));
                     }
                 }
             }
         }
+
+        drop(visited);
+        drop(to_visit);
 
         for (procref, (_, location)) in self.must_be_pure.directive.iter() {
             if let Some(impurevec) = self.impure_procs.get_violators(*procref) {
@@ -806,7 +842,7 @@ impl<'o> AnalyzeObjectTree<'o> {
             let mut visited = HashSet::<ProcRef<'o>>::new();
             let mut to_visit = VecDeque::<(ProcRef<'o>, CallStack)>::new();
             if let Some(procscalled) = self.call_tree.get(procref) {
-                for (proccalled, location, new_context) in procscalled {
+                for (proccalled, location, new_context, _src, _is_exact) in procscalled {
                     let mut callstack = CallStack::default();
                     callstack.add_step(*proccalled, *location, *new_context);
                     to_visit.push_back((*proccalled, callstack));
@@ -841,7 +877,7 @@ impl<'o> AnalyzeObjectTree<'o> {
                     }
                 }
                 if let Some(calledvec) = self.call_tree.get(&nextproc) {
-                    for (proccalled, location, new_context) in calledvec.iter() {
+                    for (proccalled, location, new_context, _src, _is_exact) in calledvec.iter() {
                         let mut newstack = callstack.clone();
                         newstack.add_step(*proccalled, *location, *new_context);
                         to_visit.push_back((*proccalled, newstack));
@@ -975,13 +1011,6 @@ impl<'o> AnalyzeObjectTree<'o> {
         if proc.name() == "New" {
             // New() propogates via ..() and causes weirdness
             return;
-        }
-        if self.sleeping_procs.get_violators(proc).is_some() {
-            let mut next = proc.parent_proc();
-            while let Some(current) = next {
-                self.sleeping_overrides.insert_override(current, proc);
-                next = current.parent_proc();
-            }
         }
         if self.impure_procs.get_violators(proc).is_some() {
             let mut next = proc.parent_proc();
@@ -3099,6 +3128,8 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             proc,
             location,
             self.inside_newcontext != 0,
+            src,
+            is_exact,
         ));
         if let Some((privateproc, true, decllocation)) = self.env.private.get_self_or_parent(proc) {
             if self.ty != privateproc.ty() {

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -594,11 +594,11 @@ impl<'o> ViolatingOverrides<'o> {
     }
 }
 
-/// An edge in the call tree: the proc called, where it was called, whether the
-/// call was made in a new context (`spawn`), the static type of the receiver,
-/// and whether the call is exact (`..()`, `new`, self- and global calls, which
-/// never dispatch to an override).
-type CallEdge<'o> = (ProcRef<'o>, Location, bool, TypeRef<'o>, bool);
+/// An edge in the call tree: proc called, call site, whether it's a new context
+/// (`spawn`), the receiver type, whether the call is exact (never dispatches to
+/// an override), and whether it runs on the caller's own object (self-calls,
+/// `..()`, `.()`) so the receiver is inherited rather than taken from `src`.
+type CallEdge<'o> = (ProcRef<'o>, Location, bool, TypeRef<'o>, bool, bool);
 
 /// A deeper analysis of an ObjectTree
 pub struct AnalyzeObjectTree<'o> {
@@ -754,16 +754,18 @@ impl<'o> AnalyzeObjectTree<'o> {
                     .register(self.context)
             }
 
+            let procref_type = procref.ty();
             if let Some(calledvec) = self.call_tree.get(procref) {
-                for (proccalled, location, new_context, src, is_exact) in calledvec.iter() {
+                for (proccalled, location, new_context, src, is_exact, inherit_receiver) in calledvec.iter() {
                     let mut newstack = CallStack::default();
                     newstack.add_step(*proccalled, *location, *new_context);
-                    to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, *src, *is_exact));
+                    let receiver = if *inherit_receiver { procref_type } else { *src };
+                    to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, receiver, *is_exact));
                 }
             }
 
-            let procref_type_index = procref.ty().index();
-            while let Some((nextproc, callstack, new_context, parent_proc, src, is_exact)) =
+            let procref_type_index = procref_type.index();
+            while let Some((nextproc, callstack, new_context, parent_proc, receiver, is_exact)) =
                 to_visit.pop_front()
             {
                 if new_context {
@@ -805,21 +807,21 @@ impl<'o> AnalyzeObjectTree<'o> {
                     continue;
                 }
 
-                // Dispatch is bounded by the receiver's static type: an
-                // override can only be reached if its type is `src` or a
-                // descendant of it. Exact calls (`..()`, `new`, self-calls,
-                // global calls) never dispatch to an override at all.
+                // Only overrides at or below the receiver type can be dispatched
+                // to; they run on the same object, so keep the same receiver.
                 if !is_exact && nextproc.ty().index() != self.objtree.root().index() {
-                    nextproc.recurse_children_within(src, &mut |child_proc| {
-                        to_visit.push_back((child_proc, callstack.clone(), false, nextproc, src, true));
+                    nextproc.recurse_children_within(receiver, &mut |child_proc| {
+                        to_visit.push_back((child_proc, callstack.clone(), false, nextproc, receiver, true));
                     });
                 }
 
                 if let Some(calledvec) = self.call_tree.get(&nextproc) {
-                    for (proccalled, location, new_context, call_src, call_is_exact) in calledvec.iter() {
+                    for (proccalled, location, new_context, call_src, call_is_exact, call_inherit) in calledvec.iter() {
                         let mut newstack = callstack.clone();
                         newstack.add_step(*proccalled, *location, *new_context);
-                        to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, *call_src, *call_is_exact));
+                        // Self-calls inherit this receiver; explicit calls use their own.
+                        let call_receiver = if *call_inherit { receiver } else { *call_src };
+                        to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, call_receiver, *call_is_exact));
                     }
                 }
             }
@@ -842,7 +844,7 @@ impl<'o> AnalyzeObjectTree<'o> {
             let mut visited = HashSet::<ProcRef<'o>>::new();
             let mut to_visit = VecDeque::<(ProcRef<'o>, CallStack)>::new();
             if let Some(procscalled) = self.call_tree.get(procref) {
-                for (proccalled, location, new_context, _src, _is_exact) in procscalled {
+                for (proccalled, location, new_context, _src, _is_exact, _inherit) in procscalled {
                     let mut callstack = CallStack::default();
                     callstack.add_step(*proccalled, *location, *new_context);
                     to_visit.push_back((*proccalled, callstack));
@@ -877,7 +879,7 @@ impl<'o> AnalyzeObjectTree<'o> {
                     }
                 }
                 if let Some(calledvec) = self.call_tree.get(&nextproc) {
-                    for (proccalled, location, new_context, _src, _is_exact) in calledvec.iter() {
+                    for (proccalled, location, new_context, _src, _is_exact, _inherit) in calledvec.iter() {
                         let mut newstack = callstack.clone();
                         newstack.add_step(*proccalled, *location, *new_context);
                         to_visit.push_back((*proccalled, newstack));
@@ -2394,9 +2396,10 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 self.check_type_sleepers(self.ty, location, unscoped_name);
                 let src = self.ty;
                 if let Some(proc) = self.ty.get_proc(unscoped_name) {
-                    self.visit_call(location, src, proc, args, false, local_vars)
+                    // Unscoped call: runs on the current object, receiver inherited.
+                    self.visit_call(location, src, proc, args, false, true, local_vars)
                 } else if unscoped_name == "__PROC__" {
-                    self.visit_call(location, src, self.proc_ref, args, false, local_vars)
+                    self.visit_call(location, src, self.proc_ref, args, false, true, local_vars)
                 } else if unscoped_name == "SpacemanDMM_unlint" {
                     // Escape hatch for cases like `src` in macros used in
                     // global procs.
@@ -2422,16 +2425,14 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             Term::SelfCall(args) => {
                 let src = self.ty;
                 let proc = self.proc_ref;
-                // Self calls are exact, and won't ever call an override.
-                self.visit_call(location, src, proc, args, true, local_vars)
+                self.visit_call(location, src, proc, args, true, true, local_vars)
             },
             Term::ParentCall(args) => {
                 self.calls_parent = true;
                 if let Some(proc) = self.proc_ref.parent_proc() {
                     // TODO: if args are empty, call w/ same args
                     let src = self.ty;
-                    // Parent calls are exact, and won't ever call an override.
-                    self.visit_call(location, src, proc, args, true, local_vars)
+                    self.visit_call(location, src, proc, args, true, true, local_vars)
                 } else {
                     error(location, format!("proc has no parent: {}", self.proc_ref))
                         .with_errortype("proc_has_no_parent")
@@ -2441,7 +2442,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             },
             Term::GlobalCall(global_name, args) => {
                 if let Some(proc) = self.objtree.root().get_proc(global_name) {
-                    self.visit_call(location, self.objtree.root(), proc, args, true, local_vars)
+                    self.visit_call(location, self.objtree.root(), proc, args, true, false, local_vars)
                 } else {
                     error(location, format!("undefined global proc: {global_name:?}"))
                         .register(self.context);
@@ -2616,6 +2617,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                 // New calls are exact: `new /datum()` will always call
                 // `/datum/New()` and never an override.
                 true,
+                false,
                 local_vars,
             );
         } else if typepath.path != "/list"
@@ -2856,7 +2858,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
                                 .register(self.context);
                             }
                         }
-                        self.visit_call(location, ty, proc, arguments, false, local_vars)
+                        self.visit_call(location, ty, proc, arguments, false, false, local_vars)
                     } else {
                         error(location, format!("undefined proc: {name:?} on {ty}"))
                             .register(self.context);
@@ -2955,7 +2957,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             StaticType::Type(typeref) => {
                 // Its been overloaded, assume they really know they want to do this
                 if let Some(proc) = typeref.get_proc(operator) {
-                    return self.visit_call(location, typeref, proc, &[], true, local_vars);
+                    return self.visit_call(location, typeref, proc, &[], true, false, local_vars);
                 }
                 typeref.get().pretty_path()
             },
@@ -3122,6 +3124,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         proc: ProcRef<'o>,
         args: &'o [Expression],
         is_exact: bool,
+        inherit_receiver: bool,
         local_vars: &mut HashMap<Ident, LocalVar<'o>>,
     ) -> Analysis<'o> {
         self.env.call_tree.entry(self.proc_ref).or_default().push((
@@ -3130,6 +3133,7 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             self.inside_newcontext != 0,
             src,
             is_exact,
+            inherit_receiver,
         ));
         if let Some((privateproc, true, decllocation)) = self.env.private.get_self_or_parent(proc) {
             if self.ty != privateproc.ty() {

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -819,8 +819,8 @@ impl<'o> AnalyzeObjectTree<'o> {
                     for (proccalled, location, new_context, call_src, call_is_exact, call_inherit) in calledvec.iter() {
                         let mut newstack = callstack.clone();
                         newstack.add_step(*proccalled, *location, *new_context);
-                        // Self-calls inherit this receiver; explicit calls use their own.
-                        let call_receiver = if *call_inherit { receiver } else { *call_src };
+                        // Self-calls run on nextproc's own type, not the broader receiver used to find nextproc itself.
+                        let call_receiver = if *call_inherit { nextproc.ty() } else { *call_src };
                         to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, call_receiver, *call_is_exact));
                     }
                 }

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -808,10 +808,11 @@ impl<'o> AnalyzeObjectTree<'o> {
                 }
 
                 // Only overrides at or below the receiver type can be dispatched
-                // to; they run on the same object, so keep the same receiver.
+                // to; once dispatched, the candidate's own type is a tighter
+                // bound on the runtime object than the original receiver.
                 if !is_exact && nextproc.ty().index() != self.objtree.root().index() {
                     nextproc.recurse_children_within(receiver, &mut |child_proc| {
-                        to_visit.push_back((child_proc, callstack.clone(), false, nextproc, receiver, true));
+                        to_visit.push_back((child_proc, callstack.clone(), false, nextproc, child_proc.ty(), true));
                     });
                 }
 
@@ -819,8 +820,8 @@ impl<'o> AnalyzeObjectTree<'o> {
                     for (proccalled, location, new_context, call_src, call_is_exact, call_inherit) in calledvec.iter() {
                         let mut newstack = callstack.clone();
                         newstack.add_step(*proccalled, *location, *new_context);
-                        // Self-calls run on nextproc's own type, not the broader receiver used to find nextproc itself.
-                        let call_receiver = if *call_inherit { nextproc.ty() } else { *call_src };
+                        // Self-calls inherit this receiver; explicit calls use their own.
+                        let call_receiver = if *call_inherit { receiver } else { *call_src };
                         to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, call_receiver, *call_is_exact));
                     }
                 }

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -798,6 +798,10 @@ impl<'o> AnalyzeObjectTree<'o> {
                 if self.sleep_exempt.get(nextproc).is_some() {
                     continue;
                 }
+                // Skip A->B->C chains when a B->C chain would be detected.
+                if self.must_not_sleep.directive.contains_key(&nextproc) {
+                    continue;
+                }
 
                 if let Some(sleepvec) = self.sleeping_procs.get_violators(nextproc) {
                     let parent_proc_type_index = parent_proc.ty().index();

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -598,7 +598,14 @@ impl<'o> ViolatingOverrides<'o> {
 /// (`spawn`), the receiver type, whether the call is exact (never dispatches to
 /// an override), and whether it runs on the caller's own object (self-calls,
 /// `..()`, `.()`) so the receiver is inherited rather than taken from `src`.
-type CallEdge<'o> = (ProcRef<'o>, Location, bool, TypeRef<'o>, bool, bool);
+struct CallEdge<'o> {
+    proc: ProcRef<'o>,
+    location: Location,
+    new_context: bool,
+    src: TypeRef<'o>,
+    is_exact: bool,
+    inherit_receiver: bool,
+}
 
 /// A deeper analysis of an ObjectTree
 pub struct AnalyzeObjectTree<'o> {
@@ -756,11 +763,22 @@ impl<'o> AnalyzeObjectTree<'o> {
 
             let procref_type = procref.ty();
             if let Some(calledvec) = self.call_tree.get(procref) {
-                for (proccalled, location, new_context, src, is_exact, inherit_receiver) in calledvec.iter() {
+                for each in calledvec.iter() {
                     let mut newstack = CallStack::default();
-                    newstack.add_step(*proccalled, *location, *new_context);
-                    let receiver = if *inherit_receiver { procref_type } else { *src };
-                    to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, receiver, *is_exact));
+                    newstack.add_step(each.proc, each.location, each.new_context);
+                    let receiver = if each.inherit_receiver {
+                        procref_type
+                    } else {
+                        each.src
+                    };
+                    to_visit.push_back((
+                        each.proc,
+                        newstack,
+                        each.new_context,
+                        each.proc,
+                        receiver,
+                        each.is_exact,
+                    ));
                 }
             }
 
@@ -785,7 +803,8 @@ impl<'o> AnalyzeObjectTree<'o> {
                     let parent_proc_type_index = parent_proc.ty().index();
                     let next_proc_type_index = nextproc.ty().index();
 
-                    let proc_is_on_same_type_as_setting = next_proc_type_index == procref_type_index;
+                    let proc_is_on_same_type_as_setting =
+                        next_proc_type_index == procref_type_index;
                     let proc_is_override = next_proc_type_index != parent_proc_type_index;
 
                     let desc = if proc_is_on_same_type_as_setting && proc_is_override {
@@ -812,17 +831,35 @@ impl<'o> AnalyzeObjectTree<'o> {
                 // bound on the runtime object than the original receiver.
                 if !is_exact && nextproc.ty().index() != self.objtree.root().index() {
                     nextproc.recurse_children_within(receiver, &mut |child_proc| {
-                        to_visit.push_back((child_proc, callstack.clone(), false, nextproc, child_proc.ty(), true));
+                        to_visit.push_back((
+                            child_proc,
+                            callstack.clone(),
+                            false,
+                            nextproc,
+                            child_proc.ty(),
+                            true,
+                        ));
                     });
                 }
 
                 if let Some(calledvec) = self.call_tree.get(&nextproc) {
-                    for (proccalled, location, new_context, call_src, call_is_exact, call_inherit) in calledvec.iter() {
+                    for each in calledvec.iter() {
                         let mut newstack = callstack.clone();
-                        newstack.add_step(*proccalled, *location, *new_context);
+                        newstack.add_step(each.proc, each.location, each.new_context);
                         // Self-calls inherit this receiver; explicit calls use their own.
-                        let call_receiver = if *call_inherit { receiver } else { *call_src };
-                        to_visit.push_back((*proccalled, newstack, *new_context, *proccalled, call_receiver, *call_is_exact));
+                        let call_receiver = if each.inherit_receiver {
+                            receiver
+                        } else {
+                            each.src
+                        };
+                        to_visit.push_back((
+                            each.proc,
+                            newstack,
+                            each.new_context,
+                            each.proc,
+                            call_receiver,
+                            each.is_exact,
+                        ));
                     }
                 }
             }
@@ -845,10 +882,10 @@ impl<'o> AnalyzeObjectTree<'o> {
             let mut visited = HashSet::<ProcRef<'o>>::new();
             let mut to_visit = VecDeque::<(ProcRef<'o>, CallStack)>::new();
             if let Some(procscalled) = self.call_tree.get(procref) {
-                for (proccalled, location, new_context, _src, _is_exact, _inherit) in procscalled {
+                for each in procscalled {
                     let mut callstack = CallStack::default();
-                    callstack.add_step(*proccalled, *location, *new_context);
-                    to_visit.push_back((*proccalled, callstack));
+                    callstack.add_step(each.proc, each.location, each.new_context);
+                    to_visit.push_back((each.proc, callstack));
                 }
             }
             while let Some((nextproc, callstack)) = to_visit.pop_front() {
@@ -880,10 +917,10 @@ impl<'o> AnalyzeObjectTree<'o> {
                     }
                 }
                 if let Some(calledvec) = self.call_tree.get(&nextproc) {
-                    for (proccalled, location, new_context, _src, _is_exact, _inherit) in calledvec.iter() {
+                    for each in calledvec.iter() {
                         let mut newstack = callstack.clone();
-                        newstack.add_step(*proccalled, *location, *new_context);
-                        to_visit.push_back((*proccalled, newstack));
+                        newstack.add_step(each.proc, *location, each.new_context);
+                        to_visit.push_back((each.proc, newstack));
                     }
                 }
             }
@@ -2443,7 +2480,15 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
             },
             Term::GlobalCall(global_name, args) => {
                 if let Some(proc) = self.objtree.root().get_proc(global_name) {
-                    self.visit_call(location, self.objtree.root(), proc, args, true, false, local_vars)
+                    self.visit_call(
+                        location,
+                        self.objtree.root(),
+                        proc,
+                        args,
+                        true,
+                        false,
+                        local_vars,
+                    )
                 } else {
                     error(location, format!("undefined global proc: {global_name:?}"))
                         .register(self.context);
@@ -3128,14 +3173,18 @@ impl<'o, 's> AnalyzeProc<'o, 's> {
         inherit_receiver: bool,
         local_vars: &mut HashMap<Ident, LocalVar<'o>>,
     ) -> Analysis<'o> {
-        self.env.call_tree.entry(self.proc_ref).or_default().push((
-            proc,
-            location,
-            self.inside_newcontext != 0,
-            src,
-            is_exact,
-            inherit_receiver,
-        ));
+        self.env
+            .call_tree
+            .entry(self.proc_ref)
+            .or_default()
+            .push(CallEdge {
+                proc,
+                location,
+                new_context: self.inside_newcontext != 0,
+                src,
+                is_exact,
+                inherit_receiver,
+            });
         if let Some((privateproc, true, decllocation)) = self.env.private.get_self_or_parent(proc) {
             if self.ty != privateproc.ty() {
                 error(

--- a/crates/dreamchecker/src/lib.rs
+++ b/crates/dreamchecker/src/lib.rs
@@ -748,7 +748,9 @@ impl<'o> AnalyzeObjectTree<'o> {
         let mut visited = HashSet::<ProcRef<'o>>::with_capacity(total_procs);
         let mut to_visit =
             VecDeque::<(ProcRef<'o>, CallStack, bool, ProcRef<'o>, TypeRef<'o>, bool)>::new();
-        for (procref, &(_, location)) in self.must_not_sleep.directive.iter() {
+        let mut must_not_sleep: Vec<_> = self.must_not_sleep.directive.iter().collect();
+        must_not_sleep.sort_by_key(|(procref, _)| procref.get().location);
+        for (procref, &(_, location)) in must_not_sleep {
             if !visited.insert(*procref) {
                 continue;
             }
@@ -872,7 +874,9 @@ impl<'o> AnalyzeObjectTree<'o> {
         drop(visited);
         drop(to_visit);
 
-        for (procref, (_, location)) in self.must_be_pure.directive.iter() {
+        let mut must_be_pure: Vec<_> = self.must_be_pure.directive.iter().collect();
+        must_be_pure.sort_by_key(|(procref, _)| procref.get().location);
+        for (procref, (_, location)) in must_be_pure {
             if let Some(impurevec) = self.impure_procs.get_violators(*procref) {
                 error(
                     procref.get().location,

--- a/crates/dreamchecker/src/test_helpers.rs
+++ b/crates/dreamchecker/src/test_helpers.rs
@@ -30,23 +30,36 @@ pub fn check_errors_match<S: Into<Cow<'static, str>>>(buffer: S, errorlist: &[(u
     let errors = context.errors();
     let mut iter = errors.iter();
     for (line, column, desc) in errorlist {
-        let nexterror = iter.next().unwrap();
-        if nexterror.location().line != *line
-            || nexterror.location().column != *column
-            || nexterror.description() != *desc
-        {
-            panic!(
-                "possible feature regression in dreamchecker:\nexpected error: {}:{}:{}\nfound error:    {}:{}:{}",
-                *line,
-                *column,
-                *desc,
-                nexterror.location().line,
-                nexterror.location().column,
-                nexterror.description()
-            );
+        let nexterror_option = iter.next();
+        match nexterror_option {
+            Some(nexterror) => {
+                if nexterror.location().line != *line
+                    || nexterror.location().column != *column
+                    || nexterror.description() != *desc
+                {
+                    panic!(
+                        "possible feature regression in dreamchecker, expected {}:{}:{}, found {}:{}:{}",
+                        *line,
+                        *column,
+                        *desc,
+                        nexterror.location().line,
+                        nexterror.location().column,
+                        nexterror.description()
+                    );
+                }
+            },
+            None => {
+                panic!(
+                    "possible feature regression in dreamchecker, expected {}:{}:{}, found no additional errors!",
+                    *line,
+                    *column,
+                    *desc
+                );
+            },
         }
     }
-    if iter.next().is_some() {
-        panic!("found more errors than was expected");
+    if let Some(error) = iter.next() {
+        let error_loc = error.location();
+        panic!("found more errors than was expected: {}:{}:{}", error_loc.line, error_loc.column, error.description());
     }
 }

--- a/crates/dreamchecker/tests/pure_tests.rs
+++ b/crates/dreamchecker/tests/pure_tests.rs
@@ -1,0 +1,48 @@
+extern crate dreamchecker as dc;
+
+use dc::test_helpers::check_errors_match;
+
+const PURE_ERRORS: &[(u32, u16, &str)] = &[
+    (12, 16, "/mob/proc/test2 sets SpacemanDMM_should_be_pure but calls a /proc/impure that does impure operations"),
+];
+
+#[test]
+fn pure() {
+    let code = r##"
+/proc/pure()
+    return 1
+/proc/impure()
+    world << "foo"
+/proc/foo()
+    pure()
+/proc/bar()
+    impure()
+/mob/proc/test()
+    set SpacemanDMM_should_be_pure = TRUE
+    return foo()
+/mob/proc/test2()
+    set SpacemanDMM_should_be_pure = TRUE
+    bar()
+"##.trim();
+    check_errors_match(code, PURE_ERRORS);
+}
+
+// these tests are separate because the ordering the errors are reported in isn't determinate and I CBF figuring out why -spookydonut Jan 2020
+// TODO: find out why
+const PURE2_ERRORS: &[(u32, u16, &str)] = &[
+    (5, 5, "call to pure proc test discards return value"),
+];
+
+#[test]
+fn pure2() {
+    let code = r##"
+/mob/proc/test()
+    set SpacemanDMM_should_be_pure = TRUE
+    return 1
+/mob/proc/test2()
+    test()
+/mob/proc/test3()
+    return test()
+"##.trim();
+    check_errors_match(code, PURE2_ERRORS);
+}

--- a/crates/dreamchecker/tests/sleep_tests.rs
+++ b/crates/dreamchecker/tests/sleep_tests.rs
@@ -1,12 +1,11 @@
+
 extern crate dreamchecker as dc;
 
-use dc::test_helpers::check_errors_match;
+use dc::test_helpers::{check_errors_match, parse_a_file_for_test};
 
-pub const SLEEP_ERRORS: &[(u32, u16, &str)] = &[(
-    16,
-    16,
-    "/mob/proc/test3 sets SpacemanDMM_should_not_sleep but calls blocking proc /proc/sleepingproc",
-)];
+const SLEEP_ERRORS: &[(u32, u16, &str)] = &[
+    (16, 16, "/mob/proc/test3 sets SpacemanDMM_should_not_sleep but calls blocking proc /proc/sleepingproc"),
+];
 
 #[test]
 fn sleep() {
@@ -42,12 +41,11 @@ fn sleep() {
 /mob/proc/test6()
     set SpacemanDMM_should_not_sleep = TRUE
     spawnthensleepproc()
-"##
-    .trim();
+"##.trim();
     check_errors_match(code, SLEEP_ERRORS);
 }
 
-pub const SLEEP_ERRORS2: &[(u32, u16, &str)] = &[
+const SLEEP_ERRORS2: &[(u32, u16, &str)] = &[
     (8, 21, "/mob/living/proc/bar calls /mob/living/proc/foo which has override child proc that sleeps /mob/living/carbon/proc/foo"),
 ];
 
@@ -77,8 +75,7 @@ fn sleep2() {
     sleep(1)
 /mob/living/thing()
     . = ..()
-"##
-    .trim();
+"##.trim();
     check_errors_match(code, SLEEP_ERRORS2);
 }
 
@@ -109,14 +106,13 @@ fn sleep3() {
     sleep(1)
 /atom/movable/thing()
     . = ..()
-"##
-    .trim();
+"##.trim();
     check_errors_match(code, &[
         (8, 23, "/atom/movable/proc/bar calls /atom/movable/proc/foo which has override child proc that sleeps /mob/proc/foo"),
     ]);
 }
 
-pub const SLEEP_ERROR4: &[(u32, u16, &str)] = &[
+const SLEEP_ERROR4: &[(u32, u16, &str)] = &[
     (1, 16, "/mob/proc/test1 sets SpacemanDMM_should_not_sleep but calls blocking built-in(s)"),
     (1, 16, "/mob/proc/test1 sets SpacemanDMM_should_not_sleep but calls blocking proc /mob/proc/test2"),
     (1, 16, "/mob/proc/test1 sets SpacemanDMM_should_not_sleep but calls blocking proc /client/proc/checksoundquery"),
@@ -149,14 +145,13 @@ fn sleep4() {
 /mob/proc/test2()
     var/client/C = new /client
     C.MeasureText()
-"##
-    .trim();
+"##.trim();
     check_errors_match(code, SLEEP_ERROR4);
 }
 
 // Test overrides and for regression of issue #267
-pub const SLEEP_ERROR5: &[(u32, u16, &str)] = &[
-        (7, 19, "/datum/sub/proc/checker sets SpacemanDMM_should_not_sleep but calls blocking proc /proc/sleeper"),
+const SLEEP_ERROR5: &[(u32, u16, &str)] = &[
+    (7, 19, "/datum/sub/proc/checker sets SpacemanDMM_should_not_sleep but calls blocking proc /proc/sleeper"),
 ];
 
 #[test]
@@ -176,53 +171,129 @@ fn sleep5() {
 
 /datum/hijack/proxy()
         sleep(1)
-"##
-    .trim();
+"##.trim();
     check_errors_match(code, SLEEP_ERROR5);
 }
 
-pub const PURE_ERRORS: &[(u32, u16, &str)] = &[
-    (12, 16, "/mob/proc/test2 sets SpacemanDMM_should_be_pure but calls a /proc/impure that does impure operations"),
+// Test overrides and for regression of issue #355
+const SLEEP_ERROR6: &[(u32, u16, &str)] = &[
+    (4, 24, "/datum/choiced/proc/is_valid sets SpacemanDMM_should_not_sleep but calls blocking proc /proc/stoplag"),
 ];
 
 #[test]
-fn pure() {
-    let code = r#"
-/proc/pure()
-    return 1
-/proc/impure()
-    world << "foo"
-/proc/foo()
-    pure()
-/proc/bar()
-    impure()
-/mob/proc/test()
-    set SpacemanDMM_should_be_pure = TRUE
-    return foo()
-/mob/proc/test2()
-    set SpacemanDMM_should_be_pure = TRUE
-    bar()
-"#
-    .trim();
-    check_errors_match(code, PURE_ERRORS);
+fn sleep6() {
+    let code = r##"
+/datum/proc/is_valid(value)
+    set SpacemanDMM_should_not_sleep = 1
+
+/datum/choiced/is_valid(value)
+    get_choices()
+
+/datum/choiced/proc/get_choices()
+    init_possible_values()
+
+/datum/choiced/proc/init_possible_values()
+
+/datum/choiced/ai_core_display/init_possible_values()
+    stoplag()
+
+/proc/stoplag()
+    sleep(1)
+"##.trim();
+    check_errors_match(code, SLEEP_ERROR6);
 }
 
-// these tests are separate because the ordering the errors are reported in isn't determinate and I CBF figuring out why -spookydonut Jan 2020
-// TODO: find out why
-pub const PURE2_ERRORS: &[(u32, u16, &str)] =
-    &[(5, 5, "call to pure proc test discards return value")];
+// When there are transitive errors for a sleeping proc (sleep_caller in this case) only the first will be returned
+#[test]
+fn sleep7() {
+    let code = r##"
+/proc/sleeper()
+    sleep(1)
+
+/proc/sleep_caller()
+    sleeper()
+
+/proc/nosleep1()
+    set SpacemanDMM_should_not_sleep = 1
+    sleep_caller()
+
+/proc/nosleep2()
+    set SpacemanDMM_should_not_sleep = 1
+    sleep_caller()
+"##.trim();
+    let context = parse_a_file_for_test(code);
+    let errors = context.errors();
+    assert_eq!(1, errors.len());
+
+    // the parser or dreamchecker does shit in a random order and i CBA to find out why
+    for error in errors.iter() {
+        assert_eq!("must_not_sleep", error.errortype().unwrap());
+    }
+}
+
+// Testing a possible infinite loop?
+#[test]
+fn sleep8() {
+    let code = r##"
+/proc/sleeper()
+    sleep(1)
+
+/proc/sleep_caller()
+    nosleep()
+    nosleep()
+    nosleep()
+    nosleep()
+    sleeper()
+
+/proc/nosleep()
+    set SpacemanDMM_should_not_sleep = 1
+    sleep_caller()
+"##.trim();
+    check_errors_match(code, &[
+        (11, 14, "/proc/nosleep sets SpacemanDMM_should_not_sleep but calls blocking proc /proc/sleeper"),
+    ]);
+}
+
+// Testing avoidance of false positive from overrides of different type chains
+#[test]
+fn sleep9() {
+    let code = r##"
+/proc/main()
+    set SpacemanDMM_should_not_sleep = 1
+    var/datum/override1/O = new
+    O.StartTest()
+
+/datum/proc/CommonProc()
+    return
+
+/datum/override1/proc/StartTest()
+    CommonProc()
+
+/datum/override2/CommonProc()
+    sleep(1)
+"##.trim();
+    check_errors_match(code, &[]);
+}
+
+// /obj is a "redirected" child of /atom/movable, not a path-descendant, so a
+// sleeping override under /obj used to be invisible to dispatch on /atom.
+const SLEEP_ERROR10: &[(u32, u16, &str)] = &[
+    (1, 14, "/proc/perform calls /atom/proc/container_resist_act which has override child proc that sleeps /obj/machinery/dna_scannernew/proc/container_resist_act"),
+];
 
 #[test]
-fn pure2() {
+fn sleep10() {
     let code = r##"
-/mob/proc/test()
-    set SpacemanDMM_should_be_pure = TRUE
-    return 1
-/mob/proc/test2()
-    test()
-/mob/proc/test3()
-    return test()
-"##
-    .trim();
-    check_errors_match(code, PURE2_ERRORS);
+/proc/perform()
+    set SpacemanDMM_should_not_sleep = 1
+    var/atom/A
+    A.container_resist_act()
+
+/atom/proc/container_resist_act()
+    return
+
+/obj/machinery/dna_scannernew/container_resist_act()
+    sleep(1)
+"##.trim();
+    check_errors_match(code, SLEEP_ERROR10);
 }

--- a/crates/dreammaker/src/objtree.rs
+++ b/crates/dreammaker/src/objtree.rs
@@ -313,6 +313,21 @@ impl<'a> TypeRef<'a> {
         }
     }
 
+    /// Recursively visit this and all child **types**.
+    pub fn recurse_types<F: FnMut(TypeRef<'a>)>(&self, f: &mut F) {
+        f(*self);
+        for child in self.children() {
+            child.recurse_types(f);
+        }
+        //else we dont include things like /turf, /obj and /mob
+        for parent_typed_idx in &self.tree.redirected_parent_types {
+            let parent_typed = &self.tree.graph[parent_typed_idx.index()];
+            if parent_typed.parent_type_index().unwrap() == self.index() {
+                TypeRef::new(self.tree, *parent_typed_idx).recurse_types(f);
+            }
+        }
+    }
+
     /// Recursively visit this and all parent **types**.
     pub fn visit_parent_types<F: FnMut(TypeRef<'a>)>(&self, f: &mut F) {
         let mut next = Some(*self);
@@ -626,7 +641,23 @@ impl<'a> ProcRef<'a> {
 
     /// Recursively visit this and all public-facing procs which override it.
     pub fn recurse_children<F: FnMut(ProcRef<'a>)>(self, f: &mut F) {
-        self.ty.recurse(&mut move |ty| {
+        self.ty.recurse_types(&mut move |ty| {
+            if let Some(proc) = ty.get().procs.get(self.name) {
+                f(ProcRef {
+                    ty,
+                    list: &proc.value,
+                    name: self.name,
+                    idx: proc.value.len() - 1,
+                });
+            }
+        });
+    }
+
+    /// Recursively visit all procs which override this one,
+    /// bounded to descendants of `src` (the static type of the receiver at
+    /// the call site) rather than the whole subtree below this proc's type.
+    pub fn recurse_children_within<F: FnMut(ProcRef<'a>)>(self, src: TypeRef<'a>, f: &mut F) {
+        src.recurse_types(&mut move |ty| {
             if let Some(proc) = ty.get().procs.get(self.name) {
                 f(ProcRef {
                     ty,
@@ -692,6 +723,7 @@ impl<'a> std::hash::Hash for ProcRef<'a> {
 pub struct ObjectTree {
     graph: Vec<Type>,
     types: BTreeMap<String, NodeIndex>,
+    redirected_parent_types: Vec<NodeIndex>,
 }
 
 impl ObjectTree {
@@ -818,6 +850,7 @@ impl Default for ObjectTreeBuilder {
         let mut tree = ObjectTree {
             graph: Vec::with_capacity(0x4000),
             types: Default::default(),
+            redirected_parent_types: Vec::new(),
         };
         tree.graph.push(Type {
             path: String::new(),
@@ -983,7 +1016,11 @@ impl ObjectTreeBuilder {
                 }
             };
 
-            self.inner.graph[type_idx.index()].parent_type = idx;
+            let type_ref = &mut self.inner.graph[type_idx.index()];
+            type_ref.parent_type = idx;
+            if type_ref.parent_path != idx {
+                self.inner.redirected_parent_types.push(type_idx);
+            }
         }
     }
 

--- a/crates/dreammaker/src/objtree.rs
+++ b/crates/dreammaker/src/objtree.rs
@@ -317,13 +317,16 @@ impl<'a> TypeRef<'a> {
     pub fn recurse_types<F: FnMut(TypeRef<'a>)>(&self, f: &mut F) {
         f(*self);
         for child in self.children() {
-            child.recurse_types(f);
+            // Exclude children which have a parent_type set to something else.
+            if child.parent_type == self.idx {
+                child.recurse_types(f);
+            }
         }
-        //else we dont include things like /turf, /obj and /mob
-        for parent_typed_idx in &self.tree.redirected_parent_types {
-            let parent_typed = &self.tree.graph[parent_typed_idx.index()];
-            if parent_typed.parent_type_index().unwrap() == self.index() {
-                TypeRef::new(self.tree, *parent_typed_idx).recurse_types(f);
+        // Search for all types which have a parent_type set to this type.
+        for &parent_typed_idx in &self.tree.redirected_parent_types {
+            let parent_typed = &self.tree[parent_typed_idx];
+            if parent_typed.parent_type == self.idx {
+                TypeRef::new(self.tree, parent_typed_idx).recurse_types(f);
             }
         }
     }


### PR DESCRIPTION
Based on #356 and finished with some additional tweaks that I noticed while fixing issues I had on /tg/ locally

Fixes https://github.com/SpaceManiac/SpacemanDMM/issues/355



Some additional changes on top of that PRs original changes:
- since /obj, /mob and /turf are not path-descendant from atom they could be missed in some specific cases. Added a new test for that (sleep10) and fixed it via redirected_parent_types. This was also the issue I was running into on /tg/
- Fixes false positives that triggered on Cyberboss version. We now bound the override lookup to the static receiver type.

The rest is similar, the override tracking system is gone and we now walk the call tree instead. Kept the test case from Cyberboss too (test9)

Also kept the split up test files and improved test helpers.